### PR TITLE
The bounds on pflex are fixed

### DIFF
--- a/src/core/flexible_demand.jl
+++ b/src/core/flexible_demand.jl
@@ -21,8 +21,8 @@ end
 function variable_total_flex_demand_active(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
     pflex = _PM.var(pm, nw)[:pflex] = JuMP.@variable(pm.model,
         [i in _PM.ids(pm, nw, :load)], base_name="$(nw)_pflex",
-        lower_bound = _PM.ref(pm, nw, :load, i, "pd") * (1 - _PM.ref(pm, nw, :load, i, "p_shift_down_max")),
-        upper_bound = _PM.ref(pm, nw, :load, i, "pd") * (1 + _PM.ref(pm, nw, :load, i, "p_shift_up_max")),
+        lower_bound = 0,
+        upper_bound = _PM.ref(pm, nw, :load, i, "pd") * (1 + _PM.ref(pm, nw, :load, i, "p_shift_up_max")), # not strictly nessesary and could be removed - redundant due to other bounds
         start = _PM.comp_start_value(_PM.ref(pm, nw, :load, i), "pd")
     )
 


### PR DESCRIPTION
Bounds on variable "pflex" in the flexible demand model are fixed according to email exchange.

Closes #51 