### PR TITLE
Add methods to existing functions

### DIFF
--- a/src/core/dimensions.jl
+++ b/src/core/dimensions.jl
@@ -243,11 +243,13 @@ end
 
 """
     similar_ids(pm::PowerModels.AbstractPowerModel, n::Int; kwargs...)
+    similar_ids(data::Dict{String,Any}, n::Int; kwargs...)
+    similar_ids(dim::Dict{Symbol,Any}, n::Int; kwargs...)
 
 Sorted vector containing nw ids that have the same coordinates along dimensions as `n` except for dimensions passed in `kwargs`.
 
 `kwargs` must be of the form `name = <value>` or `name = <interval>` or `name = <subset>`,
-where `name` is the name of a dimension of `pm`.
+where `name` is the name of a dimension of `pm`, `data` or `dim`.
 
 # Examples
 ```julia-repl
@@ -257,8 +259,9 @@ julia> similar_ids(pm, 3; hour = [6,12,18,24])
 julia> similar_ids(pm, 3; hour = 24, scenario = 3)
 ```
 """
-function similar_ids(pm::_PM.AbstractPowerModel, n::Int; kwargs...)::Vector{Int}
-    dim = pm.ref[:dim]
+function similar_ids end
+
+function similar_ids(dim::Dict{Symbol,Any}, n::Int; kwargs...)::Vector{Int}
     names = keys(dim[:pos])
     offset = dim[:offset]
     li = dim[:li]
@@ -267,13 +270,18 @@ function similar_ids(pm::_PM.AbstractPowerModel, n::Int; kwargs...)::Vector{Int}
     ndims(nws) >= 1 ? vec(nws) : [nws]
 end
 
+similar_ids(data::Dict{String,Any}, n::Int; kwargs...) = similar_ids(data["dim"], n; kwargs...)
+similar_ids(pm::_PM.AbstractPowerModel, n::Int; kwargs...) = similar_ids(pm.ref[:dim], n; kwargs...)
+
 """
     similar_id(pm::PowerModels.AbstractPowerModel, n::Int; kwargs...)
+    similar_id(data::Dict{String,Any}, n::Int; kwargs...)
+    similar_id(dim::Dict{Symbol,Any}, n::Int; kwargs...)
 
 Nw id that has the same coordinates along dimensions as `n` except for dimensions passed in `kwargs`.
 
 `kwargs` must be of the form `name = <value>`, where `name` is the name of a dimension of
-`pm`.
+`pm`, `data` or `dim`.
 
 # Examples
 ```julia-repl
@@ -281,8 +289,9 @@ julia> similar_id(pm, 3; hour = 24)
 julia> similar_id(pm, 3; hour = 24, scenario = 3)
 ```
 """
-function similar_id(pm::_PM.AbstractPowerModel, n::Int; kwargs...)::Int
-    dim = pm.ref[:dim]
+function similar_id end
+
+function similar_id(dim::Dict{Symbol,Any}, n::Int; kwargs...)::Int
     names = keys(dim[:pos])
     offset = dim[:offset]
     li = dim[:li]
@@ -290,13 +299,19 @@ function similar_id(pm::_PM.AbstractPowerModel, n::Int; kwargs...)::Int
     li[ntuple(i -> get(kwargs, names[i], ci_n[i])::Int, ndims(li))...]
 end
 
+similar_id(data::Dict{String,Any}, n::Int; kwargs...) = similar_id(data["dim"], n; kwargs...)
+similar_id(pm::_PM.AbstractPowerModel, n::Int; kwargs...) = similar_id(pm.ref[:dim], n; kwargs...)
+
 """
     first_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol...)
+    first_id(data::Dict{String,Any}, n::Int, dimension::Symbol...)
+    first_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
 
-Return the first network in `pm` along `dimension` while keeping the other dimensions fixed.
+Return the first network in `pm`, `data` or `dim` along `dimension` while keeping the other dimensions fixed.
 """
-function first_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...)
-    dim = pm.ref[:dim]
+function first_id end
+
+function first_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
     names = keys(dim[:pos])
     offset = dim[:offset]
     li = dim[:li]
@@ -304,13 +319,19 @@ function first_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...)
     li[ntuple(i -> names[i] in dimension ? 1 : ci_n[i], ndims(li))...]
 end
 
+first_id(data::Dict{String,Any}, n::Int, dimension::Symbol...) = first_id(data["dim"], n, dimension...)
+first_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...) = first_id(pm.ref[:dim], n, dimension...)
+
 """
     last_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol...)
+    last_id(data::Dict{String,Any}, n::Int, dimension::Symbol...)
+    last_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
 
-Return the last network in `pm` along `dimension` while keeping the other dimensions fixed.
+Return the last network in `pm`, `data` or `dim` along `dimension` while keeping the other dimensions fixed.
 """
-function last_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...)
-    dim = pm.ref[:dim]
+function last_id end
+
+function last_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
     names = keys(dim[:pos])
     offset = dim[:offset]
     li = dim[:li]
@@ -318,13 +339,19 @@ function last_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...)
     li[ntuple(i -> names[i] in dimension ? size(li,i) : ci_n[i], ndims(li))...]
 end
 
+last_id(data::Dict{String,Any}, n::Int, dimension::Symbol...) = last_id(data["dim"], n, dimension...)
+last_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...) = last_id(pm.ref[:dim], n, dimension...)
+
 """
     prev_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
+    prev_id(data::Dict{String,Any}, n::Int, dimension::Symbol)
+    prev_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)
 
-Return the previous network in `pm` along `dimension` while keeping the other dimensions fixed.
+Return the previous network in `pm`, `data` or `dim` along `dimension` while keeping the other dimensions fixed.
 """
-function prev_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Int
-    dim = pm.ref[:dim]
+function prev_id end
+
+function prev_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Int
     pos_d = dim[:pos][dimension]
     offset = dim[:offset]
     li = dim[:li]
@@ -332,13 +359,19 @@ function prev_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Int
     li[ntuple(i -> i == pos_d ? ci_n[i]-1 : ci_n[i], ndims(li))...]
 end
 
+prev_id(data::Dict{String,Any}, n::Int, dimension::Symbol) = prev_id(data["dim"], n, dimension)
+prev_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = prev_id(pm.ref[:dim], n, dimension)
+
 """
     prev_ids(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
+    prev_ids(data::Dict{String,Any}, n::Int, dimension::Symbol)
+    prev_ids(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)
 
-Return the previous networks in `pm` along `dimension` while keeping the other dimensions fixed.
+Return the previous networks in `pm`, `data` or `dim` along `dimension` while keeping the other dimensions fixed.
 """
-function prev_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Vector{Int}
-    dim = pm.ref[:dim]
+function prev_ids end
+
+function prev_ids(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Vector{Int}
     pos_d = dim[:pos][dimension]
     offset = dim[:offset]
     li = dim[:li]
@@ -346,13 +379,19 @@ function prev_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Vector
     li[CartesianIndex(ci_n[1:pos_d-1]), CartesianIndices((1:ci_n[pos_d]-1,)), CartesianIndex(ci_n[pos_d+1:end])]
 end
 
+prev_ids(data::Dict{String,Any}, n::Int, dimension::Symbol) = prev_ids(data["dim"], n, dimension)
+prev_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = prev_ids(pm.ref[:dim], n, dimension)
+
 """
     next_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
+    next_id(data::Dict{String,Any}, n::Int, dimension::Symbol)
+    next_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)
 
-Return the next network in `pm` along `dimension` while keeping the other dimensions fixed.
+Return the next network in `pm`, `data` or `dim` along `dimension` while keeping the other dimensions fixed.
 """
-function next_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Int
-    dim = pm.ref[:dim]
+function next_id end
+
+function next_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Int
     pos_d = dim[:pos][dimension]
     offset = dim[:offset]
     li = dim[:li]
@@ -360,19 +399,28 @@ function next_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Int
     li[ntuple(i -> i == pos_d ? ci_n[i]+1 : ci_n[i], ndims(li))...]
 end
 
+next_id(data::Dict{String,Any}, n::Int, dimension::Symbol) = next_id(data["dim"], n, dimension)
+next_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = next_id(pm.ref[:dim], n, dimension)
+
 """
     next_ids(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
+    next_ids(data::Dict{String,Any}, n::Int, dimension::Symbol)
+    next_ids(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)
 
-Return the next networks in `pm` along `dimension` while keeping the other dimensions fixed.
+Return the next networks in `pm`, `data` or `dim` along `dimension` while keeping the other dimensions fixed.
 """
-function next_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol)::Vector{Int}
-    dim = pm.ref[:dim]
+function next_ids end
+
+function next_ids(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Vector{Int}
     pos_d = dim[:pos][dimension]
     offset = dim[:offset]
     li = dim[:li]
     ci_n = Tuple(dim[:ci][n-offset])
     li[CartesianIndex(ci_n[1:pos_d-1]), CartesianIndices((ci_n[pos_d]+1:size(li,pos_d),)), CartesianIndex(ci_n[pos_d+1:end])]
 end
+
+next_ids(data::Dict{String,Any}, n::Int, dimension::Symbol) = next_ids(data["dim"], n, dimension)
+next_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = next_ids(pm.ref[:dim], n, dimension)
 
 
 ## Query properties of nw ids

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -140,96 +140,112 @@
     end
 
     @testset "similar_ids" begin
-        @test _FP.similar_ids(pm, 7)                           == [7]
-        @test _FP.similar_ids(pm, 7, hour=4)                   == [8]
-        @test _FP.similar_ids(pm, 7, scenario=1)               == [3]
-        @test _FP.similar_ids(pm, 7, hour=4, scenario=1)       == [4]
-        @test _FP.similar_ids(pm, 7, hour=2:4)                 == [6,7,8]
-        @test _FP.similar_ids(pm, 7, hour=[2,4])               == [6,8]
-        @test _FP.similar_ids(pm, 7, scenario=1:3)             == [3,7,11]
-        @test _FP.similar_ids(pm, 7, scenario=[1,3])           == [3,11]
-        @test _FP.similar_ids(pm, 7, hour=[2,4], scenario=1:3) == [2,4,6,8,10,12]
-        @test _FP.similar_ids(pm_shift, 31)                    == [31]
+        @test _FP.similar_ids(dim, 7)                           == [7]
+        @test _FP.similar_ids(dim, 7, hour=4)                   == [8]
+        @test _FP.similar_ids(dim, 7, scenario=1)               == [3]
+        @test _FP.similar_ids(dim, 7, hour=4, scenario=1)       == [4]
+        @test _FP.similar_ids(dim, 7, hour=2:4)                 == [6,7,8]
+        @test _FP.similar_ids(dim, 7, hour=[2,4])               == [6,8]
+        @test _FP.similar_ids(dim, 7, scenario=1:3)             == [3,7,11]
+        @test _FP.similar_ids(dim, 7, scenario=[1,3])           == [3,11]
+        @test _FP.similar_ids(dim, 7, hour=[2,4], scenario=1:3) == [2,4,6,8,10,12]
+        @test _FP.similar_ids(dim_shift, 31)                    == [31]
+        @test _FP.similar_ids(dt, 7) == _FP.similar_ids(dim, 7)
+        @test _FP.similar_ids(pm, 7) == _FP.similar_ids(dim, 7)
     end
 
     @testset "similar_id" begin
-        @test _FP.similar_id(pm, 7)                     == 7
-        @test _FP.similar_id(pm, 7, hour=4)             == 8
-        @test _FP.similar_id(pm, 7, scenario=1)         == 3
-        @test _FP.similar_id(pm, 7, hour=4, scenario=1) == 4
-        @test _FP.similar_id(pm_shift, 31)              == 31
+        @test _FP.similar_id(dim, 7)                     == 7
+        @test _FP.similar_id(dim, 7, hour=4)             == 8
+        @test _FP.similar_id(dim, 7, scenario=1)         == 3
+        @test _FP.similar_id(dim, 7, hour=4, scenario=1) == 4
+        @test _FP.similar_id(dim_shift, 31)              == 31
+        @test _FP.similar_id(dt, 7) == _FP.similar_id(dim, 7)
+        @test _FP.similar_id(pm, 7) == _FP.similar_id(dim, 7)
     end
 
     @testset "first_id" begin
-        @test _FP.first_id(pm, 17, :hour) == 17
-        @test _FP.first_id(pm, 18, :hour) == 17
-        @test _FP.first_id(pm, 19, :hour) == 17
-        @test _FP.first_id(pm, 20, :hour) == 17
-        @test _FP.first_id(pm, 16, :scenario) == 16
-        @test _FP.first_id(pm, 19, :scenario) == 15
-        @test _FP.first_id(pm, 22, :scenario) == 14
-        @test _FP.first_id(pm, 13, :hour, :scenario) == 13
-        @test _FP.first_id(pm, 16, :hour, :scenario) == 13
-        @test _FP.first_id(pm, 21, :hour, :scenario) == 13
-        @test _FP.first_id(pm, 24, :hour, :scenario) == 13
-        @test _FP.first_id(pm_shift, 41, :hour) == 41
+        @test _FP.first_id(dim, 17, :hour) == 17
+        @test _FP.first_id(dim, 18, :hour) == 17
+        @test _FP.first_id(dim, 19, :hour) == 17
+        @test _FP.first_id(dim, 20, :hour) == 17
+        @test _FP.first_id(dim, 16, :scenario) == 16
+        @test _FP.first_id(dim, 19, :scenario) == 15
+        @test _FP.first_id(dim, 22, :scenario) == 14
+        @test _FP.first_id(dim, 13, :hour, :scenario) == 13
+        @test _FP.first_id(dim, 16, :hour, :scenario) == 13
+        @test _FP.first_id(dim, 21, :hour, :scenario) == 13
+        @test _FP.first_id(dim, 24, :hour, :scenario) == 13
+        @test _FP.first_id(dim_shift, 41, :hour) == 41
+        @test _FP.first_id(dt, 17, :hour) == _FP.first_id(dim, 17, :hour)
+        @test _FP.first_id(pm, 17, :hour) == _FP.first_id(dim, 17, :hour)
     end
 
     @testset "last_id" begin
-        @test _FP.last_id(pm,  8, :hour) ==  8
-        @test _FP.last_id(pm,  7, :hour) ==  8
-        @test _FP.last_id(pm,  6, :hour) ==  8
-        @test _FP.last_id(pm,  5, :hour) ==  8
-        @test _FP.last_id(pm,  9, :scenario) ==  9
-        @test _FP.last_id(pm,  6, :scenario) == 10
-        @test _FP.last_id(pm,  3, :scenario) == 11
-        @test _FP.last_id(pm, 12, :hour, :scenario) == 12
-        @test _FP.last_id(pm,  9, :hour, :scenario) == 12
-        @test _FP.last_id(pm,  4, :hour, :scenario) == 12
-        @test _FP.last_id(pm,  1, :hour, :scenario) == 12
-        @test _FP.last_id(pm_shift, 32, :hour) == 32
+        @test _FP.last_id(dim,  8, :hour) ==  8
+        @test _FP.last_id(dim,  7, :hour) ==  8
+        @test _FP.last_id(dim,  6, :hour) ==  8
+        @test _FP.last_id(dim,  5, :hour) ==  8
+        @test _FP.last_id(dim,  9, :scenario) ==  9
+        @test _FP.last_id(dim,  6, :scenario) == 10
+        @test _FP.last_id(dim,  3, :scenario) == 11
+        @test _FP.last_id(dim, 12, :hour, :scenario) == 12
+        @test _FP.last_id(dim,  9, :hour, :scenario) == 12
+        @test _FP.last_id(dim,  4, :hour, :scenario) == 12
+        @test _FP.last_id(dim,  1, :hour, :scenario) == 12
+        @test _FP.last_id(dim_shift, 32, :hour) == 32
+        @test _FP.last_id(dt, 8, :hour) == _FP.last_id(dim, 8, :hour)
+        @test _FP.last_id(pm, 8, :hour) == _FP.last_id(dim, 8, :hour)
     end
 
     @testset "prev_id" begin
-        @test_throws BoundsError _FP.prev_id(pm, 17, :hour)
-        @test _FP.prev_id(pm, 18, :hour) == 17
-        @test _FP.prev_id(pm, 19, :hour) == 18
-        @test _FP.prev_id(pm, 20, :hour) == 19
-        @test_throws BoundsError _FP.prev_id(pm, 16, :scenario)
-        @test _FP.prev_id(pm, 19, :scenario) == 15
-        @test _FP.prev_id(pm, 22, :scenario) == 18
-        @test _FP.prev_id(pm_shift, 42, :hour) == 41
+        @test_throws BoundsError _FP.prev_id(dim, 17, :hour)
+        @test _FP.prev_id(dim, 18, :hour) == 17
+        @test _FP.prev_id(dim, 19, :hour) == 18
+        @test _FP.prev_id(dim, 20, :hour) == 19
+        @test_throws BoundsError _FP.prev_id(dim, 16, :scenario)
+        @test _FP.prev_id(dim, 19, :scenario) == 15
+        @test _FP.prev_id(dim, 22, :scenario) == 18
+        @test _FP.prev_id(dim_shift, 42, :hour) == 41
+        @test _FP.prev_id(dt, 18, :hour) == _FP.prev_id(dim, 18, :hour)
+        @test _FP.prev_id(pm, 18, :hour) == _FP.prev_id(dim, 18, :hour)
     end
 
     @testset "prev_ids" begin
-        @test _FP.prev_ids(pm, 17, :hour) == []
-        @test _FP.prev_ids(pm, 18, :hour) == [17]
-        @test _FP.prev_ids(pm, 20, :hour) == [17,18,19]
-        @test _FP.prev_ids(pm, 16, :scenario) == []
-        @test _FP.prev_ids(pm, 19, :scenario) == [15]
-        @test _FP.prev_ids(pm, 22, :scenario) == [14,18]
-        @test _FP.prev_ids(pm_shift, 42, :hour) == [41]
+        @test _FP.prev_ids(dim, 17, :hour) == []
+        @test _FP.prev_ids(dim, 18, :hour) == [17]
+        @test _FP.prev_ids(dim, 20, :hour) == [17,18,19]
+        @test _FP.prev_ids(dim, 16, :scenario) == []
+        @test _FP.prev_ids(dim, 19, :scenario) == [15]
+        @test _FP.prev_ids(dim, 22, :scenario) == [14,18]
+        @test _FP.prev_ids(dim_shift, 42, :hour) == [41]
+        @test _FP.prev_ids(dt, 17, :hour) == _FP.prev_ids(dim, 17, :hour)
+        @test _FP.prev_ids(pm, 17, :hour) == _FP.prev_ids(dim, 17, :hour)
     end
 
     @testset "next_id" begin
-        @test _FP.next_id(pm, 5, :hour) ==  6
-        @test _FP.next_id(pm, 6, :hour) ==  7
-        @test _FP.next_id(pm, 7, :hour) ==  8
-        @test_throws BoundsError _FP.next_id(pm, 8, :hour)
-        @test_throws BoundsError _FP.next_id(pm, 9, :scenario)
-        @test _FP.next_id(pm, 6, :scenario) == 10
-        @test _FP.next_id(pm, 3, :scenario) ==  7
-        @test _FP.next_id(pm_shift, 29, :hour) == 30
+        @test _FP.next_id(dim, 5, :hour) ==  6
+        @test _FP.next_id(dim, 6, :hour) ==  7
+        @test _FP.next_id(dim, 7, :hour) ==  8
+        @test_throws BoundsError _FP.next_id(dim, 8, :hour)
+        @test_throws BoundsError _FP.next_id(dim, 9, :scenario)
+        @test _FP.next_id(dim, 6, :scenario) == 10
+        @test _FP.next_id(dim, 3, :scenario) ==  7
+        @test _FP.next_id(dim_shift, 29, :hour) == 30
+        @test _FP.next_id(dt, 5, :hour) == _FP.next_id(dim, 5, :hour)
+        @test _FP.next_id(pm, 5, :hour) == _FP.next_id(dim, 5, :hour)
     end
 
     @testset "next_ids" begin
-        @test _FP.next_ids(pm, 5, :hour) == [6,7,8]
-        @test _FP.next_ids(pm, 7, :hour) == [8]
-        @test _FP.next_ids(pm, 8, :hour) == []
-        @test _FP.next_ids(pm, 9, :scenario) == []
-        @test _FP.next_ids(pm, 6, :scenario) == [10]
-        @test _FP.next_ids(pm, 3, :scenario) == [7,11]
-        @test _FP.next_ids(pm_shift, 29, :hour) == [30,31,32]
+        @test _FP.next_ids(dim, 5, :hour) == [6,7,8]
+        @test _FP.next_ids(dim, 7, :hour) == [8]
+        @test _FP.next_ids(dim, 8, :hour) == []
+        @test _FP.next_ids(dim, 9, :scenario) == []
+        @test _FP.next_ids(dim, 6, :scenario) == [10]
+        @test _FP.next_ids(dim, 3, :scenario) == [7,11]
+        @test _FP.next_ids(dim_shift, 29, :hour) == [30,31,32]
+        @test _FP.next_ids(dt, 5, :hour) == _FP.next_ids(dim, 5, :hour)
+        @test _FP.next_ids(pm, 5, :hour) == _FP.next_ids(dim, 5, :hour)
     end
 
     @testset "coord" begin


### PR DESCRIPTION
While working on the JSON converter I realized that it is useful to call some of the functions that handle multidimensional nw ids in situations that I had not imagined at first, such as from within the `ref_extension` functions, where a `pm` variable is not yet available and only the `ref` and `data` dictionaries can be accessed.

This PR adds methods to use `data` or `dim` instead of `pm` as first argument of the following functions:
- `similar_ids`;
- `similar_id`;
- `first_id`;
- `last_id`;
- `prev_id`;
- `prev_ids`;
- `next_id`;
- `next_ids`.