### PR TITLE
Misc. improvements

### DIFF
--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -38,7 +38,7 @@ function constraint_power_balance_acne_strg(pm::_PM.AbstractWModels, n::Int, i::
 end
 
 # Power balance including candidate storage & flexible demand
-function constraint_power_balance_acne_dcne_flex(pm::_PM.AbstractDCPModel, n::Int, i::Int, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, pd, qd, gs, bs)
+function constraint_power_balance_acne_dcne_flex(pm::_PM.AbstractDCPModel, n::Int, i::Int, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, gs, bs)
     p                = _PM.var(pm, n, :p)
     pg               = _PM.var(pm, n, :pg)
     pconv_grid_ac_ne = _PM.var(pm, n, :pconv_tf_fr_ne)
@@ -55,7 +55,7 @@ function constraint_power_balance_acne_dcne_flex(pm::_PM.AbstractDCPModel, n::In
 end
 
 # Power balance (without DC equipment) including candidate storage & flexible demand
-function constraint_power_balance_acne_flex(pm::_PM.AbstractWModels, n::Int, i::Int, bus_arcs, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, bus_storage, bus_storage_ne, pd, qd, gs, bs)
+function constraint_power_balance_acne_flex(pm::_PM.AbstractWModels, n::Int, i::Int, bus_arcs, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, bus_storage, bus_storage_ne, gs, bs)
     p     = _PM.var(pm, n, :p)
     q     = _PM.var(pm, n, :q)
     p_ne  = _PM.var(pm, n, :p_ne)
@@ -75,7 +75,7 @@ function constraint_power_balance_acne_flex(pm::_PM.AbstractWModels, n::Int, i::
 end
 
 # Power balance with power interrupted by contingency - pinter (including candidate storage & flexible demand)
-function constraint_power_balance_reliability(pm::_PM.AbstractDCPModel, n::Int, i::Int, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, pd, qd, gs, bs)
+function constraint_power_balance_reliability(pm::_PM.AbstractDCPModel, n::Int, i::Int, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, gs, bs)
     p                = _PM.var(pm, n, :p)
     pg               = _PM.var(pm, n, :pg)
     pconv_grid_ac_ne = _PM.var(pm, n, :pconv_tf_fr_ne)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -58,12 +58,9 @@ function constraint_power_balance_acne_dcne_flex(pm::_PM.AbstractPowerModel, i::
     bus_storage = PowerModels.ref(pm, nw, :bus_storage, i)
     bus_storage_ne = PowerModels.ref(pm, nw, :bus_storage_ne, i)
 
-    pd = Dict(k => PowerModels.ref(pm, nw, :load, k, "pd") for k in bus_loads)
-    qd = Dict(k => PowerModels.ref(pm, nw, :load, k, "qd") for k in bus_loads)
-
     gs = Dict(k => PowerModels.ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bs = Dict(k => PowerModels.ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
-    constraint_power_balance_acne_dcne_flex(pm, nw, i, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, pd, qd, gs, bs)
+    constraint_power_balance_acne_dcne_flex(pm, nw, i, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, gs, bs)
 end
 
 "Power balance (without DC equipment) including candidate storage & flexible demand"
@@ -77,12 +74,9 @@ function constraint_power_balance_acne_flex(pm::_PM.AbstractPowerModel, i::Int; 
     bus_storage = PowerModels.ref(pm, nw, :bus_storage, i)
     bus_storage_ne = PowerModels.ref(pm, nw, :bus_storage_ne, i)
 
-    pd = Dict(k => PowerModels.ref(pm, nw, :load, k, "pd") for k in bus_loads)
-    qd = Dict(k => PowerModels.ref(pm, nw, :load, k, "qd") for k in bus_loads)
-
     gs = Dict(k => PowerModels.ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bs = Dict(k => PowerModels.ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
-    constraint_power_balance_acne_flex(pm, nw, i, bus_arcs, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, bus_storage, bus_storage_ne, pd, qd, gs, bs)
+    constraint_power_balance_acne_flex(pm, nw, i, bus_arcs, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, bus_storage, bus_storage_ne, gs, bs)
 end
 
 "Power balance with power interrupted by contingency - pinter (including candidate storage & flexible demand)"
@@ -99,13 +93,10 @@ function constraint_power_balance_reliability(pm::_PM.AbstractPowerModel, i::Int
     bus_storage = PowerModels.ref(pm, nw, :bus_storage, i)
     bus_storage_ne = PowerModels.ref(pm, nw, :bus_storage_ne, i)
 
-    pd = Dict(k => PowerModels.ref(pm, nw, :load, k, "pd") for k in bus_loads)
-    qd = Dict(k => PowerModels.ref(pm, nw, :load, k, "qd") for k in bus_loads)
-
     gs = Dict(k => PowerModels.ref(pm, nw, :shunt, k, "gs") for k in bus_shunts)
     bs = Dict(k => PowerModels.ref(pm, nw, :shunt, k, "bs") for k in bus_shunts)
 
-    constraint_power_balance_reliability(pm, nw, i, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, pd, qd, gs, bs)
+    constraint_power_balance_reliability(pm, nw, i, bus_arcs, bus_arcs_ne, bus_arcs_dc, bus_gens, bus_convs_ac, bus_convs_ac_ne, bus_loads, bus_shunts, bus_storage, bus_storage_ne, gs, bs)
 end
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -115,7 +115,7 @@ end
 function constraint_ne_branch_activation(pm::_PM.AbstractPowerModel, i::Int, prev_nws::Vector{Int}, nw::Int)
     investment_horizon = [nw]
     lifetime = _PM.ref(pm, nw, :ne_branch, i, "lifetime")
-    for n in Iterators.reverse(prev_nws[1:min(lifetime-1,length(prev_nws))])
+    for n in Iterators.reverse(prev_nws[max(end-lifetime+2,1):end])
         i in _PM.ids(pm, n, :ne_branch) ? push!(investment_horizon, n) : break
     end
     constraint_ne_branch_activation(pm, nw, i, investment_horizon)
@@ -128,7 +128,7 @@ end
 function constraint_ne_branchdc_activation(pm::_PM.AbstractPowerModel, i::Int, prev_nws::Vector{Int}, nw::Int)
     investment_horizon = [nw]
     lifetime = _PM.ref(pm, nw, :branchdc_ne, i, "lifetime")
-    for n in Iterators.reverse(prev_nws[1:min(lifetime-1,length(prev_nws))])
+    for n in Iterators.reverse(prev_nws[max(end-lifetime+2,1):end])
         i in _PM.ids(pm, n, :branchdc_ne) ? push!(investment_horizon, n) : break
     end
     constraint_ne_branchdc_activation(pm, nw, i, investment_horizon)
@@ -141,7 +141,7 @@ end
 function constraint_ne_converter_activation(pm::_PM.AbstractPowerModel, i::Int, prev_nws::Vector{Int}, nw::Int)
     investment_horizon = [nw]
     lifetime = _PM.ref(pm, nw, :convdc_ne, i, "lifetime")
-    for n in Iterators.reverse(prev_nws[1:min(lifetime-1,length(prev_nws))])
+    for n in Iterators.reverse(prev_nws[max(end-lifetime+2,1):end])
         i in _PM.ids(pm, n, :convdc_ne) ? push!(investment_horizon, n) : break
     end
     constraint_ne_converter_activation(pm, nw, i, investment_horizon)

--- a/src/core/flexible_demand.jl
+++ b/src/core/flexible_demand.jl
@@ -214,7 +214,7 @@ end
 function constraint_flexible_demand_activation(pm::_PM.AbstractPowerModel, i::Int, prev_nws::Vector{Int}, nw::Int)
     investment_horizon = [nw]
     lifetime = _PM.ref(pm, nw, :load, i, "lifetime")
-    for n in Iterators.reverse(prev_nws[1:min(lifetime-1,length(prev_nws))])
+    for n in Iterators.reverse(prev_nws[max(end-lifetime+2,1):end])
         i in _PM.ids(pm, n, :load) ? push!(investment_horizon, n) : break
     end
     constraint_flexible_demand_activation(pm, nw, i, investment_horizon)

--- a/src/core/storage.jl
+++ b/src/core/storage.jl
@@ -382,7 +382,7 @@ end
 function constraint_ne_storage_activation(pm::_PM.AbstractPowerModel, i::Int, prev_nws::Vector{Int}, nw::Int)
     investment_horizon = [nw]
     lifetime = _PM.ref(pm, nw, :ne_storage, i, "lifetime")
-    for n in Iterators.reverse(prev_nws[1:min(lifetime-1,length(prev_nws))])
+    for n in Iterators.reverse(prev_nws[max(end-lifetime+2,1):end])
         i in _PM.ids(pm, n, :ne_storage) ? push!(investment_horizon, n) : break
     end
     constraint_ne_storage_activation(pm, nw, i, investment_horizon)

--- a/test/data/CIGRE_MV_benchmark_network.m
+++ b/test/data/CIGRE_MV_benchmark_network.m
@@ -1,8 +1,8 @@
 function mpc = CIGRE_MV_benchmark_network
 % CIGRE_MV_BENCHMARK_NETWORK Returns MATPOWER case for the CIGRE medium-voltage benchmark network
-% 
+%
 % References:
-% [1] CIGRE TF C6.04.02, "Benchmark Systems for Network Integration of Renewable and Distributed 
+% [1] CIGRE TF C6.04.02, "Benchmark Systems for Network Integration of Renewable and Distributed
 % Energy Resources", CIGRE, Technical Brochure 575, 2014.
 %
 % EDITS:
@@ -16,6 +16,9 @@ mpc.version = '2';
 %%-----  Power Flow Data  -----%%
 %% system MVA base
 mpc.baseMVA = 1;
+
+%% conversion ratio between energy and power
+mpc.time_elapsed = 1.0
 
 %% bus data
 % bus_i type      pd       qd   gs   bs bus_area   vm   va base_kv zone    vmax    vmin

--- a/test/data/CIGRE_MV_benchmark_network_tnep.m
+++ b/test/data/CIGRE_MV_benchmark_network_tnep.m
@@ -28,6 +28,9 @@ mpc.version = '2';
 %% system MVA base
 mpc.baseMVA = 1.0;
 
+%% conversion ratio between energy and power
+mpc.time_elapsed = 1.0
+
 %% bus data
 % bus_i type      pd       qd   gs   bs bus_area   vm   va base_kv zone    vmax    vmin
 mpc.bus = [

--- a/test/data/CIGRE_MV_benchmark_network_with_costs.m
+++ b/test/data/CIGRE_MV_benchmark_network_with_costs.m
@@ -1,8 +1,8 @@
 function mpc = CIGRE_MV_benchmark_network_with_costs
 % CIGRE_MV_BENCHMARK_NETWORK_WITH_COSTS Returns MATPOWER case for the CIGRE medium-voltage benchmark network with generator cost
-% 
+%
 % References:
-% [1] CIGRE TF C6.04.02, "Benchmark Systems for Network Integration of Renewable and Distributed 
+% [1] CIGRE TF C6.04.02, "Benchmark Systems for Network Integration of Renewable and Distributed
 % Energy Resources", CIGRE, Technical Brochure 575, 2014.
 %
 % EDITS:
@@ -18,6 +18,9 @@ mpc.version = '2';
 %%-----  Power Flow Data  -----%%
 %% system MVA base
 mpc.baseMVA = 1;
+
+%% conversion ratio between energy and power
+mpc.time_elapsed = 1.0
 
 %% bus data
 % bus_i type      pd       qd   gs   bs bus_area   vm   va base_kv zone    vmax    vmin

--- a/test/data/multiple_years/case67/case67.m
+++ b/test/data/multiple_years/case67/case67.m
@@ -3,6 +3,7 @@
 function mpc = case67acdc_scopf
 mpc.version = '2';
 mpc.baseMVA = 100.0;
+mpc.time_elapsed = 1.0;
 
 %% area data
 %	area	refbus
@@ -287,6 +288,3 @@ mpc.branchdc = [
 					5       7       0.0012   0   0   1575    1575    1575     1;
 					3       9       0.0012   0   0   1575    1575    1575     1;
  ];
-
-
- 


### PR DESCRIPTION
- #### Add `time_elapsed` where missing in Matpower input files

  This removes a couple of annoying warnings previously shown when running tests. (By the way, there are still some spurious lines emitted by Cbc when running package tests, but [this is a known bug of Cbc](https://github.com/jump-dev/Cbc.jl/issues/168).)

- #### Fix link between ids of investment variables and indicator variables

  Closes #110.

  Constraint templates that link investment variables (= whether an investment is made) to indicator variables (= whether an expansion candidate is built) sometimes failed to provide the correct set of network indices (`investment_horizon`) to constraint implementations.

- #### Remove unused params from power balance constraints involving flex loads

  When using flexible demand, the consumption of loads is represented by `pflex` and `qflex` variables. The `pd` and `qd` parameters, which represent the reference demand, are not used in the power balance equations in that case. Although not necessary, they were still required by some constraints: instantiating a model threw an error when using a dict not containing `qd`.