### PR TITLE
Experimental JSON converter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.1"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
@@ -32,10 +33,9 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Juniper = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CSV", "Cbc", "DataFrames", "Ipopt", "JSON", "Juniper", "SCS", "Test"]
+test = ["CSV", "Cbc", "DataFrames", "Ipopt", "Juniper", "SCS", "Test"]

--- a/src/FlexPlan.jl
+++ b/src/FlexPlan.jl
@@ -58,4 +58,10 @@ include("form/bf.jl")
 include("form/bfarad.jl")
 include("formconv/dcp.jl")
 
+
+# Submodules
+
+include("json_converter/json_converter.jl")
+using .JSONConverter
+
 end

--- a/src/json_converter/base.jl
+++ b/src/json_converter/base.jl
@@ -1,0 +1,195 @@
+"""
+    convert_JSON(file; <keyword arguments>)
+    convert_JSON(dict; <keyword arguments>)
+
+Convert a JSON `file` or a `dict` conforming to the FlexPlan WP3 API into a FlexPlan.jl dict.
+
+Costs are scaled with the assumption that every representative year represents 10 years.
+
+# Arguments
+- `number_of_hours::Union{Int,Nothing}=nothing`: parse only the first hours of the
+  file/dict.
+- `number_of_scenarios::Union{Int,Nothing}=nothing`: parse only the first scenarios of the
+  file/dict.
+- `number_of_years::Union{Int,Nothing}=nothing`: parse only the first years of the
+  file/dict.
+- `cost_scale_factor::Float64=1.0`: scale factor for all costs.
+- `init_data_extensions::Vector{<:Function}=Function[]`: functions to be applied to the
+  target dict after its initialization. They must have exactly one argument (the target
+  dict) and can modify it; the return value is unused.
+- `sn_data_extensions::Vector{<:Function}=Function[]`: functions to be applied to the
+  single-network dictionaries containing data for each single year, just before
+  `_FP.make_multinetwork` is called. They must have exactly one argument (the single-network
+  dict) and can modify it; the return value is unused.
+
+# Extended help
+Features of FlexPlan WP3 API not supported in FlexPlan.jl:
+- scenario probabilities depending on year (only constant probabilities are allowed);
+- number of hours depending on scenario (all scenarios must have the same number of hours);
+- combined transmission and distribution networks;
+- PSTs;
+- curtailment of renewable generators;
+- `gridModelInputFile.converters.ratedActivePowerDC`;
+- `gridModelInputFile.storage.minEnergy`;
+- `gridModelInputFile.storage.maxAbsRamp`;
+- `gridModelInputFile.storage.maxInjRamp`;
+- uniqueness of candidate components (each candidate can be reinvested at the end of its
+  lifetime).
+"""
+function convert_JSON end
+
+function convert_JSON(file::String; kwargs...)
+    source_dict = JSON.parsefile(file)
+    convert_JSON(source_dict; kwargs...)
+end
+
+function convert_JSON(source::AbstractDict;
+        number_of_hours::Union{Int,Nothing} = nothing,
+        number_of_scenarios::Union{Int,Nothing} = nothing,
+        number_of_years::Union{Int,Nothing} = nothing,
+        cost_scale_factor::Float64 = 1.0,
+        init_data_extensions::Vector{<:Function} = Function[],
+        sn_data_extensions::Vector{<:Function} = Function[],
+    )
+
+    # Define target dict
+
+    target = Dict{String, Any}(
+        "nw"           => Dict{String,Any}(),
+        "multinetwork" => true,
+        "per_unit"     => true,
+    )
+
+    # Add dimensions
+
+    if length(unique(vcat(source["genericParameters"]["nbHours"]...))) > 1
+        Memento.error(_LOGGER, "All scenarios must have the same number of hours.") # Dimensions are implemented as a multidimensional array, so the length of one dimension cannot depend on the id along another dimension.
+    end
+    if isnothing(number_of_hours)
+        number_of_hours = first(first(source["genericParameters"]["nbHours"]))
+    elseif number_of_hours > first(first(source["genericParameters"]["nbHours"]))
+        Memento.error(_LOGGER, "$number_of_hours hours requested, but only " * string(first(first(source["genericParameters"]["nbHours"]))) * " found in input dict.")
+    end
+    _FP.add_dimension!(target, :hour, number_of_hours)
+
+    if isnothing(number_of_scenarios)
+        number_of_scenarios = source["genericParameters"]["nbScenarios"]
+    elseif number_of_scenarios > source["genericParameters"]["nbScenarios"]
+        Memento.error(_LOGGER, "$number_of_scenarios scenarios requested, but only " * string(source["genericParameters"]["nbScenarios"]) * " found in input dict.")
+    end
+    if haskey(source["genericParameters"], "scenarioProbabilities")
+        if maximum(length.(unique.(source["genericParameters"]["scenarioProbabilities"]))) > 1
+            Memento.warn(_LOGGER, "Only constant probabilities are supported for scenearios. Using first year probabilities for every year.")
+        end
+        scenario_probabilities = first(first.(source["genericParameters"]["scenarioProbabilities"]), number_of_scenarios) # The outermost `first` is needed if the user has specified a number of scenarios lower than that available.
+    else
+        scenario_probabilities = fill(1/number_of_scenarios,number_of_scenarios)
+    end
+    scenario_properties = Dict(id => Dict{String,Any}("probability"=>prob) for (id,prob) in enumerate(scenario_probabilities))
+    _FP.add_dimension!(target, :scenario, scenario_properties)
+
+    if isnothing(number_of_years)
+        number_of_years = length(source["genericParameters"]["years"])
+    elseif number_of_years > length(source["genericParameters"]["years"])
+        Memento.error(_LOGGER, "$number_of_years years requested, but only " * string(length(source["genericParameters"]["years"])) * " found in input dict.")
+    end
+    year_scale_factor = 10 # Assumption: every representative year represents 10 years
+    _FP.add_dimension!(target, :year, number_of_years; metadata = Dict{String,Any}("scale_factor"=>year_scale_factor))
+
+    # Generate ID lookup dict
+
+    lookup_acBranches = id_lookup(source["gridModelInputFile"]["acBranches"])
+    lookup_cand_acBranches = id_lookup(source["candidatesInputFile"]["acBranches"], "acBranch")
+    lookup = Dict(
+        "acBuses"           => id_lookup(source["gridModelInputFile"]["acBuses"]),
+        "acBranches"        => lookup_acBranches,
+        "transformers"      => id_lookup(source["gridModelInputFile"]["transformers"]; offset=length(lookup_acBranches)), # AC branches are split between `acBranches` and `transformers` dicts in JSON files
+        "generators"        => id_lookup(source["gridModelInputFile"]["generators"]),
+        "loads"             => id_lookup(source["gridModelInputFile"]["loads"]),
+        "storage"           => id_lookup(source["gridModelInputFile"]["storage"]),
+        "dcBuses"           => id_lookup(source["gridModelInputFile"]["dcBuses"]),
+        "dcBranches"        => id_lookup(source["gridModelInputFile"]["dcBranches"]),
+        "converters"        => id_lookup(source["gridModelInputFile"]["converters"]),
+        "cand_acBranches"   => lookup_cand_acBranches,
+        "cand_transformers" => id_lookup(source["candidatesInputFile"]["transformers"], "acBranch"; offset=length(lookup_cand_acBranches)), # AC branches are split between `acBranches` and `transformers` dicts in JSON files
+        "cand_storage"      => id_lookup(source["candidatesInputFile"]["storage"], "storage"),
+        "cand_dcBranches"   => id_lookup(source["candidatesInputFile"]["dcBranches"], "dcBranch"),
+        "cand_converters"   => id_lookup(source["candidatesInputFile"]["converters"], "converter"),
+    )
+
+    # Compute availability of candidates
+
+    year_scale_factor = _FP.dim_meta(target, :year, "scale_factor")
+    year_lookup = Dict{Int,Int}((year,y) for (y,year) in enumerate(source["genericParameters"]["years"]))
+    cand_availability = Dict{String,Any}(
+        "acBranches"   => availability(source, "acBranches",    "acBranch",  year_lookup, year_scale_factor, number_of_years),
+        "transformers" => availability(source, "transformers",  "acBranch",  year_lookup, year_scale_factor, number_of_years),
+        "loads"        => availability(source, "flexibleLoads", "load",      year_lookup, year_scale_factor, number_of_years),
+        "storage"      => availability(source, "storage",       "storage",   year_lookup, year_scale_factor, number_of_years),
+        "dcBranches"   => availability(source, "dcBranches",    "dcBranch",  year_lookup, year_scale_factor, number_of_years),
+        "converters"   => availability(source, "converters",    "converter", year_lookup, year_scale_factor, number_of_years),
+    )
+
+    # Apply init data extensions
+
+    for f! in init_data_extensions
+        f!(target)
+    end
+
+    # Build data year by year
+
+    for y in 1:number_of_years
+        sn_data = nw(source, lookup, cand_availability, y)
+        _FP.scale_data!(sn_data; year_idx=y, number_of_years, year_scale_factor, cost_scale_factor)
+        sn_data["dim"] = target["dim"]
+
+        # Apply single network data extensions
+        for f! in sn_data_extensions
+            f!(sn_data)
+        end
+
+        time_series = make_time_series(source, lookup, y, sn_data; number_of_hours, number_of_scenarios)
+        year_data = _FP.make_multinetwork(sn_data, time_series; number_of_nws=number_of_hours*number_of_scenarios, nw_id_offset=number_of_hours*number_of_scenarios*(y-1))
+        add_singular_data!(year_data, source, lookup, y)
+        _FP.import_nws!(target, year_data)
+    end
+
+    return target
+end
+
+# Define a bijective map from existing JSON String ids to FlexPlan Int ids (generated in _id_lookup)
+function id_lookup(component_vector::Vector; offset::Int=0)
+    json_ids = [d["id"] for d in component_vector]
+    return _id_lookup(json_ids, offset)
+end
+
+function id_lookup(component_vector::Vector, sub_key::String; offset::Int=0)
+    json_ids = [d[sub_key]["id"] for d in component_vector]
+    return _id_lookup(json_ids, offset)
+end
+
+function _id_lookup(json_ids::Vector, offset::Int)
+    sort!(json_ids) # Sorting prevents changes due to the order of elements in JSON files
+    int_ids = range(1+offset; length=length(json_ids))
+    lookup = Dict{String,Int}(zip(json_ids, int_ids))
+    if length(lookup) < length(json_ids)
+        Memento.error(_LOGGER, "IDs must be unique (found only $(length(lookup)) unique IDs, should be $(length(json_ids))).")
+    end
+    return lookup
+end
+
+function availability(source::AbstractDict, comp_name::String, sub_key::String, year_lookup::AbstractDict, year_scale_factor::Int, number_of_years::Int)
+    target = Dict{String,Vector{Bool}}()
+    for comp in source["candidatesInputFile"][comp_name]
+        id = comp[sub_key]["id"]
+        investment_horizon = [year_lookup[year] for year in comp["horizons"]]
+        if last(investment_horizon) - first(investment_horizon) ≥ length(investment_horizon)
+            Memento.warn(_LOGGER, "Horizon of $comp_name $id is not a contiguous set.")
+        end
+        raw_lifetime = comp["lifetime"] ÷ year_scale_factor
+        availability_horizon_start = first(investment_horizon)
+        availability_horizon_end = min(last(investment_horizon)+raw_lifetime-1, number_of_years)
+        target[id] = [availability_horizon_start ≤ y ≤ availability_horizon_end for y in 1:number_of_years]
+    end
+    return target
+end

--- a/src/json_converter/json_converter.jl
+++ b/src/json_converter/json_converter.jl
@@ -1,0 +1,17 @@
+module JSONConverter
+
+export convert_JSON
+
+using ..FlexPlan
+const _FP = FlexPlan
+import ..FlexPlan: _LOGGER
+
+import JSON
+import Memento
+
+include("base.jl")
+include("nw.jl")
+include("time_series.jl")
+include("singular_data.jl")
+
+end

--- a/src/json_converter/nw.jl
+++ b/src/json_converter/nw.jl
@@ -1,0 +1,390 @@
+# Single-network containing only fixed data (i.e. data that does not depend on year)
+function nw(source::AbstractDict, lookup::AbstractDict, cand_availability::AbstractDict, y::Int)
+    target = Dict{String,Any}(
+        "branch"       => Dict{String,Any}(),
+        "branchdc"     => Dict{String,Any}(),
+        "branchdc_ne"  => Dict{String,Any}(),
+        "bus"          => Dict{String,Any}(),
+        "busdc"        => Dict{String,Any}(),
+        "busdc_ne"     => Dict{String,Any}(),
+        "convdc"       => Dict{String,Any}(),
+        "convdc_ne"    => Dict{String,Any}(),
+        "dcline"       => Dict{String,Any}(),
+        "gen"          => Dict{String,Any}(),
+        "load"         => Dict{String,Any}(),
+        "ne_branch"    => Dict{String,Any}(),
+        "ne_storage"   => Dict{String,Any}(),
+        "shunt"        => Dict{String,Any}(),
+        "storage"      => Dict{String,Any}(),
+        "switch"       => Dict{String,Any}(),
+        "per_unit"     => true,
+        "time_elapsed" => 1.0, # Assumption: each period lasts 1 hour.
+    )
+    if haskey(source["genericParameters"], "basePower")
+        target["baseMVA"] = source["genericParameters"]["basePower"]
+    end
+
+    # AC branches are split between `acBranches` and `transformers` dicts in JSON files
+    branch_path = ["gridModelInputFile", "acBranches"]
+    for comp in walkpath(source, branch_path)
+        index     = lookup["acBranches"][comp["id"]]
+        source_id = push!(copy(branch_path), comp["id"])
+        f_bus     = lookup["acBuses"][comp["acBusOrigin"]]
+        t_bus     = lookup["acBuses"][comp["acBusExtremity"]]
+        target["branch"]["$index"] = make_branch(comp, index, source_id, f_bus, t_bus, y; transformer=false)
+    end
+    branch_path = ["gridModelInputFile", "transformers"]
+    for comp in walkpath(source, branch_path)
+        index     = lookup["transformers"][comp["id"]]
+        source_id = push!(copy(branch_path), comp["id"])
+        f_bus     = lookup["acBuses"][comp["acBusOrigin"]]
+        t_bus     = lookup["acBuses"][comp["acBusExtremity"]]
+        target["branch"]["$index"] = make_branch(comp, index, source_id, f_bus, t_bus, y; transformer=true)
+    end
+
+    branchdc_path = ["gridModelInputFile", "dcBranches"]
+    for comp in walkpath(source, branchdc_path)
+        index     = lookup["dcBranches"][comp["id"]]
+        source_id = push!(copy(branchdc_path), comp["id"])
+        fbusdc    = lookup["dcBuses"][comp["dcBusOrigin"]]
+        tbusdc    = lookup["dcBuses"][comp["dcBusExtremity"]]
+        target["branchdc"]["$index"] = make_branchdc(comp, index, source_id, fbusdc, tbusdc, y)
+    end
+
+    bus_path = ["gridModelInputFile", "acBuses"]
+    for comp in walkpath(source, bus_path)
+        index     = lookup["acBuses"][comp["id"]]
+        source_id = push!(copy(bus_path), comp["id"])
+        target["bus"]["$index"] = make_bus(comp, index, source_id)
+    end
+
+    busdc_path = ["gridModelInputFile", "dcBuses"]
+    for comp in walkpath(source, busdc_path)
+        index     = lookup["dcBuses"][comp["id"]]
+        source_id = push!(copy(busdc_path), comp["id"])
+        target["busdc"]["$index"] = make_busdc(comp, index, source_id)
+    end
+
+    convdc_path = ["gridModelInputFile", "converters"]
+    for comp in walkpath(source, convdc_path)
+        index     = lookup["converters"][comp["id"]]
+        source_id = push!(copy(convdc_path), comp["id"])
+        busac     = lookup["acBuses"][comp["acBusConnected"]]
+        busdc     = lookup["dcBuses"][comp["dcBusConnected"]]
+        typeac    = walkpath(source, bus_path)[busac]["busType"]
+        target["convdc"]["$index"] = make_convdc(comp, index, source_id, busac, busdc, typeac, y)
+    end
+
+    gen_path = ["gridModelInputFile", "generators"]
+    for comp in walkpath(source, gen_path)
+        index     = lookup["generators"][comp["id"]]
+        source_id = push!(copy(gen_path), comp["id"])
+        gen_bus   = lookup["acBuses"][comp["acBusConnected"]]
+        target["gen"]["$index"] = make_gen(comp, index, source_id, gen_bus, y)
+    end
+
+    load_path = ["gridModelInputFile", "loads"]
+    for comp in walkpath(source, load_path)
+        index     = lookup["loads"][comp["id"]]
+        source_id = push!(copy(load_path), comp["id"])
+        load_bus  = lookup["acBuses"][comp["acBusConnected"]]
+        target["load"]["$index"] = make_load(comp, index, source_id, load_bus, y)
+    end
+
+    storage_path = ["gridModelInputFile", "storage"]
+    for comp in walkpath(source, storage_path)
+        index       = lookup["storage"][comp["id"]]
+        source_id   = push!(copy(storage_path), comp["id"])
+        storage_bus = lookup["acBuses"][comp["acBusConnected"]]
+        target["storage"]["$index"] = make_storage(comp, index, source_id, storage_bus, y)
+    end
+
+    ne_branch_path = ["candidatesInputFile", "acBranches"]
+    for cand in walkpath(source, ne_branch_path)
+        comp = cand["acBranch"]
+        if cand_availability["acBranches"][comp["id"]][y]
+            index     = lookup["cand_acBranches"][comp["id"]]
+            source_id = push!(copy(ne_branch_path), comp["id"])
+            f_bus     = lookup["acBuses"][comp["acBusOrigin"]]
+            t_bus     = lookup["acBuses"][comp["acBusExtremity"]]
+            t = make_branch(comp, index, source_id, f_bus, t_bus, y; transformer=false)
+            t["construction_cost"] = cand["invCost"][y]
+            t["lifetime"]          = cand["lifetime"]
+            t["replace"]           = replace(cand, comp["id"], lookup["acBranches"]) # Assumption: specified id is that of the branch that connects the same buses.
+            target["ne_branch"]["$index"] = t
+        end
+    end
+    ne_branch_path = ["candidatesInputFile", "transformers"]
+    for cand in walkpath(source, ne_branch_path)
+        comp = cand["acBranch"]
+        if cand_availability["transformers"][comp["id"]][y]
+            index     = lookup["cand_transformers"][comp["id"]]
+            source_id = push!(copy(ne_branch_path), comp["id"])
+            f_bus     = lookup["acBuses"][comp["acBusOrigin"]]
+            t_bus     = lookup["acBuses"][comp["acBusExtremity"]]
+            t = make_branch(comp, index, source_id, f_bus, t_bus, y; transformer=true)
+            t["construction_cost"] = cand["invCost"][y]
+            t["lifetime"]          = cand["lifetime"]
+            t["replace"]           = replace(cand, comp["id"], lookup["transformers"]) # Assumption: specified id is that of the branch that connects the same buses.
+            target["ne_branch"]["$index"] = t
+        end
+    end
+
+    branchdc_ne_path = ["candidatesInputFile", "dcBranches"]
+    for cand in walkpath(source, branchdc_ne_path)
+        comp = cand["dcBranch"]
+        if cand_availability["dcBranches"][comp["id"]][y]
+            index     = lookup["cand_dcBranches"][comp["id"]]
+            source_id = push!(copy(branchdc_ne_path), comp["id"])
+            fbusdc    = lookup["dcBuses"][comp["dcBusOrigin"]]
+            tbusdc    = lookup["dcBuses"][comp["dcBusExtremity"]]
+            t = make_branchdc(comp, index, source_id, fbusdc, tbusdc, y)
+            t["cost"]     = cand["invCost"][y]
+            t["lifetime"] = cand["lifetime"]
+            target["branchdc_ne"]["$index"] = t
+        end
+    end
+
+    convdc_ne_path = ["candidatesInputFile", "converters"]
+    for cand in walkpath(source, convdc_ne_path)
+        comp = cand["converter"]
+        if cand_availability["converters"][comp["id"]][y]
+            index     = lookup["cand_converters"][comp["id"]]
+            source_id = push!(copy(convdc_ne_path), comp["id"])
+            busac     = lookup["acBuses"][comp["acBusConnected"]]
+            busdc     = lookup["dcBuses"][comp["dcBusConnected"]]
+            typeac    = walkpath(source, bus_path)[busac]["busType"]
+            t = make_convdc(comp, index, source_id, busac, busdc, typeac, y)
+            t["cost"]     = cand["invCost"][y]
+            t["lifetime"] = cand["lifetime"]
+            target["convdc_ne"]["$index"] = t
+        end
+    end
+
+    load_path = ["candidatesInputFile", "flexibleLoads"]
+    for cand in walkpath(source, load_path)
+        comp = cand["load"]
+        if cand_availability["loads"][comp["id"]][y]
+            index     = lookup["loads"][comp["id"]] # Candidate loads have same ids as existing loads
+            source_id = push!(copy(load_path), comp["id"])
+            load_bus  = lookup["acBuses"][comp["acBusConnected"]]
+            t = make_load(comp, index, source_id, load_bus, y)
+            t["cost_inv"] = cand["invCost"][y]
+            t["lifetime"] = cand["lifetime"]
+            target["load"]["$index"] = t # The candidate load replaces the existing load that has the same id and is assumed to have the same parameters as that existing load.
+        end
+    end
+
+    ne_storage_path = ["candidatesInputFile", "storage"]
+    for cand in walkpath(source, ne_storage_path)
+        comp = cand["storage"]
+        if cand_availability["storage"][comp["id"]][y]
+            index     = lookup["cand_storage"][comp["id"]]
+            source_id = push!(copy(ne_storage_path), comp["id"])
+            storage_bus = lookup["acBuses"][comp["acBusConnected"]]
+            t = make_storage(comp, index, source_id, storage_bus, y)
+            t["eq_cost"]   = cand["invCost"][y]
+            t["inst_cost"] = 0.0
+            t["lifetime"]  = cand["lifetime"]
+            target["ne_storage"]["$index"] = t
+        end
+    end
+
+    return target
+end
+
+function walkpath(node::AbstractDict, path::Vector{String})
+    for key in path
+        node = node[key]
+    end
+    return node
+end
+
+function optional_value(target::AbstractDict, target_key::String, source::AbstractDict, source_key::String)
+    if haskey(source, source_key)
+        target[target_key] = source[source_key]
+    end
+end
+
+function optional_value(target::AbstractDict, target_key::String, source::AbstractDict, source_key::String, y::Int)
+    if haskey(source, source_key) && !isempty(source[source_key])
+        target[target_key] = source[source_key][y]
+    end
+end
+
+function replace(cand::AbstractDict, id::String, comp_lookup::AbstractDict)
+    if haskey(cand, "replace")
+        if haskey(comp_lookup, cand["replace"])
+            # FlexPlan.jl only supports replacement of the only branch that connects the same buses as the candidate.
+            # That branch will be replaced, regardless of which branch is specified by `cand["replace"]`.
+            return true
+        else
+            Memento.warn(_LOGGER, "Cannot set \"$id\" to replace \"" * cand["replace"] * "\" because \"" * cand["replace"] * "\" does not exist.")
+            return false
+        end
+    else
+        return false
+    end
+end
+
+function make_branch(source::AbstractDict, index::Int, source_id::Vector{String}, f_bus::Int, t_bus::Int, y::Int; transformer::Bool)
+    target = Dict{String,Any}(
+        "index"       => index,
+        "source_id"   => source_id,
+        "f_bus"       => f_bus,
+        "t_bus"       => t_bus,
+        "br_status"   => 1, # Assumption: all branches defined in JSON file are in service.
+        "transformer" => transformer,
+        "br_x"        => source["reactance"],
+        "b_fr"        => source["susceptance"]/2,
+        "b_to"        => source["susceptance"]/2,
+        "g_fr"        => 0.0, # Assumption: all branches defined in JSON file have zero shunt conductance.
+        "g_to"        => 0.0, # Assumption: all branches defined in JSON file have zero shunt conductance.
+        "rate_a"      => source["ratedApparentPower"][y],
+        "rate_c"      => source["emergencyRating"],
+        "tap"         => source["voltageTapRatio"],
+        "shift"       => 0.0, # Assumption: all branches defined in JSON file have zero shift.
+        "angmin"      => source["minAngleDifference"],
+        "angmax"      => source["maxAngleDifference"],
+    )
+    optional_value(target, "br_r", source, "resistance")
+    return target
+end
+
+function make_branchdc(source::AbstractDict, index::Int, source_id::Vector{String}, fbusdc::Int, tbusdc::Int, y::Int)
+    target = Dict{String,Any}(
+        "index"     => index,
+        "source_id" => source_id,
+        "fbusdc"    => fbusdc,
+        "tbusdc"    => tbusdc,
+        "status"    => 1, # Assumption: all branches defined in JSON file are in service.
+        "rateA"     => source["ratedActivePower"][y],
+        "rateC"     => source["emergencyRating"],
+    )
+    return target
+end
+
+function make_bus(source::AbstractDict, index::Int, source_id::Vector{String})
+    target = Dict{String,Any}(
+        "index"     => index,
+        "bus_i"     => index,
+        "source_id" => source_id,
+        "vm"        => source["nominalVoltageMagnitude"],
+    )
+    optional_value(target, "bus_type", source, "busType")
+    if haskey(target, "bus_type") && target["bus_type"] == 3
+        target["va"] = 0.0 # Set voltage angle of reference bus to 0.0
+    end
+    optional_value(target, "base_kv",  source, "baseVoltage")
+    optional_value(target, "vmax",     source, "maxVoltageMagnitude")
+    optional_value(target, "vmin",     source, "minVoltageMagnitude")
+    if haskey(source, "location")
+        target["lat"] = source["location"][1]
+        target["lon"] = source["location"][2]
+    end
+    return target
+end
+
+function make_busdc(source::AbstractDict, index::Int, source_id::Vector{String})
+    target = Dict{String,Any}(
+        "index"     => index,
+        "busdc_i"   => index,
+        "source_id" => source_id,
+        "Vdc"       => source["nominalVoltageMagnitude"],
+        "Vdcmin"    => 0.9, # Assumption: minimum DC voltage is 0.9 p.u. for every DC bus
+        "Vdcmax"    => 1.1, # Assumption: maximum DC voltage is 1.1 p.u. for every DC bus
+    )
+    optional_value(target, "basekVdc", source, "baseVoltage")
+    return target
+end
+
+function make_convdc(source::AbstractDict, index::Int, source_id::Vector{String}, busac::Int, busdc::Int, typeac::Int, y::Int)
+    target = Dict{String,Any}(
+        "index"     => index,
+        "source_id" => source_id,
+        "status"    => 1, # Assumption: all converters defined in JSON file are in service.
+        "busac_i"   => busac,
+        "busdc_i"   => busdc,
+        "type_ac"   => typeac,
+        "type_dc"   => 3, # Assumption: all converters defined in JSON file have DC droop.
+        "Vmmin"     => 0.9, # Required by PowerModelsACDC, but not relevant, since we use an approximation where voltage magnitude is 1.0 p.u. at each AC transmission network bus
+        "Vmmax"     => 1.1, # Required by PowerModelsACDC, but not relevant, since we use an approximation where voltage magnitude is 1.0 p.u. at each AC transmission network bus
+        "Pacrated"  => source["ratedActivePowerAC"][y],
+        "Pacmin"    => -source["ratedActivePowerAC"][y],
+        "Pacmax"    => source["ratedActivePowerAC"][y],
+    )
+    return target
+end
+
+function make_gen(source::AbstractDict, index::Int, source_id::Vector{String}, gen_bus::Int, y::Int)
+    target = Dict{String,Any}(
+        "index"      => index,
+        "source_id"  => source_id,
+        "gen_status" => 1, # Assumption: all generators defined in JSON file are in service.
+        "gen_bus"    => gen_bus,
+        "pmin"       => source["minActivePower"][y],
+        "pmax"       => source["maxActivePower"][y],
+        "qmin"       => source["minReactivePower"][y],
+        "qmax"       => source["maxReactivePower"][y],
+        "vg"         => 1.0,
+        "model"      => 2, # Polynomial cost model
+        "ncost"      => 2, # 2 cost coefficients: c1 and c0
+        "cost"       => [source["generationCosts"][y], 0.0], # [c1, c0]
+    )
+    return target
+end
+
+function make_load(source::AbstractDict, index::Int, source_id::Vector{String}, load_bus::Int, y::Int)
+    target = Dict{String,Any}(
+        "index"     => index,
+        "source_id" => source_id,
+        "status"    => 1, # Assumption: all loads defined in JSON file are in service.
+        "load_bus"  => load_bus,
+        "flex"      => get(source, "isFlexible", false),
+    )
+    if haskey(source, "powerFactor")
+        target["pf_angle"] = acos(source["powerFactor"])
+    end
+    optional_value(target, "pred_rel_max",        source, "superiorBoundNCP",        y)
+    optional_value(target, "ered_rel_max",        source, "maxEnergyNotConsumed",    y)
+    optional_value(target, "pshift_up_rel_max",   source, "superiorBoundUDS",        y)
+    optional_value(target, "pshift_down_rel_max", source, "superiorBoundDDS",        y)
+    optional_value(target, "tshift_up",           source, "gracePeriodUDS",          y)
+    optional_value(target, "tshift_down",         source, "gracePeriodDDS",          y)
+    optional_value(target, "eshift_rel_max",      source, "maxEnergyShifted",        y)
+    optional_value(target, "cost_curt",           source, "valueOfLossLoad",         y)
+    optional_value(target, "cost_red",            source, "compensationConsumeLess", y)
+    if haskey(source, "compensationDemandShift") && !isempty(source["compensationDemandShift"])
+        target["cost_shift_down"] = source["compensationDemandShift"][y]
+        target["cost_shift_up"] = 0.0 # To avoid double counting. An alternative would be to split `compensationDemandShift` equally between `cost_shift_down` and `cost_shift_up`.
+    end
+    return target
+end
+
+function make_storage(source::AbstractDict, index::Int, source_id::Vector{String}, storage_bus::Int, y::Int)
+    target = Dict{String,Any}(
+        "index"                 => index,
+        "source_id"             => source_id,
+        "status"                => 1, # Assumption: all generators defined in JSON file are in service.
+        "storage_bus"           => storage_bus,
+        "energy_rating"         => source["maxEnergy"][y],
+        "charge_rating"         => source["maxAbsActivePower"][y],
+        "discharge_rating"      => source["maxInjActivePower"][y],
+        "charge_efficiency"     => source["absEfficiency"][y],
+        "discharge_efficiency"  => source["injEfficiency"][y],
+        "qmin"                  => source["minReactivePowerExchange"][y],
+        "qmax"                  => source["maxReactivePowerExchange"][y],
+        "self_discharge_rate"   => source["selfDischargeRate"][y],
+        "max_energy_absorption" => source["maxEnergyYear"][y],
+        "r"                     => 0.0, # JSON API does not support `r`. Neither Flexplan.jl does (in lossless models), however a value is required by the constraint templates `_PM.constraint_storage_losses` and `_FP.constraint_storage_losses_ne`.
+        "x"                     => 0.0, # JSON API does not support `x`. Neither Flexplan.jl does (in lossless models), however a value is required by the constraint templates `_PM.constraint_storage_losses` and `_FP.constraint_storage_losses_ne`.
+        "p_loss"                => 0.0, # JSON API does not support `p_loss`. Neither Flexplan.jl does, however a value is required by the constraint templates `_PM.constraint_storage_losses` and `_FP.constraint_storage_losses_ne`.
+        "q_loss"                => 0.0, # JSON API does not support `q_loss`. Neither Flexplan.jl does, however a value is required by the constraint templates `_PM.constraint_storage_losses` and `_FP.constraint_storage_losses_ne`.
+    )
+    # JSON API does not support storage thermal rating, but a value is required by
+    # `FlexPlan.constraint_storage_thermal_limit`. The following expression prevents it from
+    # limiting active or reactive power, even in the case of octagonal approximation of
+    # apparent power.
+    target["thermal_rating"] = 2 * max(target["charge_rating"], target["discharge_rating"], target["qmax"], -target["qmin"])
+    return target
+end

--- a/src/json_converter/singular_data.jl
+++ b/src/json_converter/singular_data.jl
@@ -1,0 +1,20 @@
+# Data to be added to specific nws only
+function add_singular_data!(target::AbstractDict, source::AbstractDict, lookup::AbstractDict, y::Int)
+    first_hour_nws = string.(_FP.nw_ids(target, hour=1, year=y))
+    last_hour_nws  = string.(_FP.nw_ids(target, hour=_FP.dim_length(target, :hour), year=y))
+    for comp in source["scenarioDataInputFile"]["storage"]
+        index = lookup["storage"][comp["id"]]
+        for s in 1:_FP.dim_length(target, :scenario)
+            target["nw"][first_hour_nws[s]]["storage"]["$index"]["energy"] = comp["initEnergy"][s][y]
+            target["nw"][last_hour_nws[s]]["storage"]["$index"]["energy"] = comp["finalEnergy"][s][y]
+        end
+    end
+    for cand in source["candidatesInputFile"]["storage"]
+        comp = cand["storageData"]
+        index = lookup["cand_storage"][comp["id"]]
+        for s in 1:_FP.dim_length(target, :scenario)
+            target["nw"][first_hour_nws[s]]["ne_storage"]["$index"]["energy"] = comp["initEnergy"][s][y]
+            target["nw"][last_hour_nws[s]]["ne_storage"]["$index"]["energy"] = comp["finalEnergy"][s][y]
+        end
+    end
+end

--- a/src/json_converter/time_series.jl
+++ b/src/json_converter/time_series.jl
@@ -1,0 +1,73 @@
+# Time series having length == number_of_hours * number_of_scenarios
+function make_time_series(source::AbstractDict, lookup::AbstractDict, y::Int, sn_data::AbstractDict; number_of_hours::Int, number_of_scenarios::Int)
+    target = Dict{String,Any}(
+        "gen"        => Dict{String,Any}(),
+        "load"       => Dict{String,Any}(),
+        "storage"    => Dict{String,Any}(),
+        "ne_storage" => Dict{String,Any}(),
+    )
+
+    for comp in source["scenarioDataInputFile"]["generators"]
+        index = lookup["generators"][comp["id"]]
+        if haskey(comp, "capacityFactor") # If gen is a RES
+            # Since FlexPlan.jl does not support curtailable generators, we fix their power to the value determined by the time series.
+            # TODO: change this once FlexPlan.jl supports curtailable generation
+            p = ts_vector(comp, "capacityFactor", y; number_of_hours, number_of_scenarios) .* sn_data["gen"]["$index"]["pmax"]
+            target["gen"]["$index"] = Dict{String,Any}("pmax" => p, "pmin" => p)
+        end
+    end
+
+    for comp in source["scenarioDataInputFile"]["loads"]
+        index = lookup["loads"][comp["id"]]
+        pd    = ts_vector(comp, "demandReference", y; number_of_hours, number_of_scenarios)
+        target["load"]["$index"] = Dict{String,Any}("pd" => pd)
+    end
+
+    for comp in source["scenarioDataInputFile"]["storage"]
+        index = lookup["storage"][comp["id"]]
+        target["storage"]["$index"] = Dict{String,Any}()
+        if haskey(comp, "powerExternalProcess")
+            p = ts_vector(comp, "powerExternalProcess", y; number_of_hours, number_of_scenarios)
+            target["storage"]["$index"]["stationary_energy_inflow"] = max.(p,0.0)
+            target["storage"]["$index"]["stationary_energy_outflow"] = -min.(p,0.0)
+        else
+            target["storage"]["$index"]["stationary_energy_inflow"] = zeros(number_of_hours*number_of_scenarios)
+            target["storage"]["$index"]["stationary_energy_outflow"] = zeros(number_of_hours*number_of_scenarios)
+        end
+        if haskey(comp, "maxAbsActivePower")
+            target["storage"]["$index"]["charge_rating"] = ts_vector(comp, "maxAbsActivePower", y; number_of_hours, number_of_scenarios) * sn_data["storage"]["$index"]["charge_rating"]
+        end
+        if haskey(comp, "maxInjActivePower")
+            target["storage"]["$index"]["discharge_rating"] = ts_vector(comp, "maxInjActivePower", y; number_of_hours, number_of_scenarios) * sn_data["storage"]["$index"]["discharge_rating"]
+        end
+    end
+
+    for cand in source["candidatesInputFile"]["storage"]
+        comp = cand["storageData"]
+        index = lookup["cand_storage"][comp["id"]]
+        target["ne_storage"]["$index"] = Dict{String,Any}()
+        if haskey(comp, "powerExternalProcess")
+            p = ts_vector(comp, "powerExternalProcess", y; number_of_hours, number_of_scenarios)
+            target["ne_storage"]["$index"]["stationary_energy_inflow"] = max.(p,0.0)
+            target["ne_storage"]["$index"]["stationary_energy_outflow"] = -min.(p,0.0)
+        else
+            target["ne_storage"]["$index"]["stationary_energy_inflow"] = zeros(number_of_hours*number_of_scenarios)
+            target["ne_storage"]["$index"]["stationary_energy_outflow"] = zeros(number_of_hours*number_of_scenarios)
+        end
+        if haskey(comp, "maxAbsActivePower")
+            target["ne_storage"]["$index"]["charge_rating"] = ts_vector(comp, "maxAbsActivePower", y; number_of_hours, number_of_scenarios) * sn_data["ne_storage"]["$index"]["charge_rating"]
+        end
+        if haskey(comp, "maxInjActivePower")
+            target["ne_storage"]["$index"]["discharge_rating"] = ts_vector(comp, "maxInjActivePower", y; number_of_hours, number_of_scenarios) * sn_data["ne_storage"]["$index"]["discharge_rating"]
+        end
+    end
+
+    return target
+end
+
+# Time series data vector from JSON component dict
+function ts_vector(comp::AbstractDict, key::String, y::Int; number_of_hours::Int, number_of_scenarios::Int)
+    # `comp[key]` is a Vector{Vector{Vector{Any}}} containing data of each scenario, year and hour
+    # Returned value is a Vector{Float64} containing data of year y and each scenario and hour
+    return mapreduce(Vector{Float64}, vcat, comp[key][s][y][1:number_of_hours] for s in 1:number_of_scenarios)
+end

--- a/test/data/json_converter/case6_input_file_2018-2019.json
+++ b/test/data/json_converter/case6_input_file_2018-2019.json
@@ -1,0 +1,2436 @@
+{
+  "genericParameters": {
+    "nbScenarios": 2,
+    "years": [
+      2030,
+      2040,
+      2050
+    ],
+    "nbHours": [
+      [
+        4,
+        4,
+        4
+      ],
+      [
+        4,
+        4,
+        4
+      ]
+    ],
+    "maxNumberOfCandidates": [
+      10,
+      10,
+      10
+    ]
+  },
+  "gridModelInputFile": {
+    "acBuses": [
+      {
+        "id": "4",
+        "location": [
+          40.5228,
+          16.2155
+        ],
+        "nominalVoltageMagnitude": 240.0,
+        "slackStatus": true,
+        "maxVoltageMagnitude": 252.0,
+        "minVoltageMagnitude": 228.0,
+        "isTransmission": true,
+        "busType": 1,
+        "characteristics": {}
+      },
+      {
+        "id": "1",
+        "location": [
+          43.4894,
+          11.7946
+        ],
+        "nominalVoltageMagnitude": 240.0,
+        "slackStatus": true,
+        "maxVoltageMagnitude": 252.0,
+        "minVoltageMagnitude": 228.0,
+        "isTransmission": true,
+        "busType": 3,
+        "characteristics": {}
+      },
+      {
+        "id": "5",
+        "location": [
+          40.1717,
+          9.0738
+        ],
+        "nominalVoltageMagnitude": 240.0,
+        "slackStatus": true,
+        "maxVoltageMagnitude": 252.0,
+        "minVoltageMagnitude": 228.0,
+        "isTransmission": true,
+        "busType": 1,
+        "characteristics": {}
+      },
+      {
+        "id": "2",
+        "location": [
+          45.3411,
+          9.9489
+        ],
+        "nominalVoltageMagnitude": 240.0,
+        "slackStatus": true,
+        "maxVoltageMagnitude": 252.0,
+        "minVoltageMagnitude": 228.0,
+        "isTransmission": true,
+        "busType": 1,
+        "characteristics": {}
+      },
+      {
+        "id": "6",
+        "location": [
+          37.4844,
+          14.1568
+        ],
+        "nominalVoltageMagnitude": 240.0,
+        "slackStatus": true,
+        "maxVoltageMagnitude": 252.0,
+        "minVoltageMagnitude": 228.0,
+        "isTransmission": true,
+        "busType": 2,
+        "characteristics": {}
+      },
+      {
+        "id": "3",
+        "location": [
+          41.8218,
+          13.8302
+        ],
+        "nominalVoltageMagnitude": 240.0,
+        "slackStatus": true,
+        "maxVoltageMagnitude": 252.0,
+        "minVoltageMagnitude": 228.0,
+        "isTransmission": true,
+        "busType": 2,
+        "characteristics": {}
+      }
+    ],
+    "dcBuses": [
+      {
+        "id": "4",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": true
+      },
+      {
+        "id": "1",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": true
+      },
+      {
+        "id": "2",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": true
+      },
+      {
+        "id": "3",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": true
+      },
+      {
+        "id": "5",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": false
+      },
+      {
+        "id": "6",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": false
+      },
+      {
+        "id": "7",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": false
+      },
+      {
+        "id": "8",
+        "location": [
+          0,
+          0
+        ],
+        "nominalVoltageMagnitude": 320,
+        "slackStatus": false
+      }
+    ],
+    "acBranches": [
+      {
+        "id": "4",
+        "acBusOrigin": "2",
+        "acBusExtremity": "4",
+        "isTransmission": true,
+        "susceptance": 0.004340277777777778,
+        "voltageTapRatio": 1.0,
+        "ratedApparentPower": [
+          100.0,
+          100.0,
+          100.0
+        ],
+        "maxAngleDifference": 1.0471975511965976,
+        "minAngleDifference": -1.0471975511965976,
+        "resistance": 23.04,
+        "reactance": 230.4,
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 100.0,
+        "isInterconnection": false
+      },
+      {
+        "id": "1",
+        "acBusOrigin": "1",
+        "acBusExtremity": "2",
+        "isTransmission": true,
+        "susceptance": 0.004340277777777778,
+        "voltageTapRatio": 1.0,
+        "ratedApparentPower": [
+          100.0,
+          100.0,
+          100.0
+        ],
+        "maxAngleDifference": 1.0471975511965976,
+        "minAngleDifference": -1.0471975511965976,
+        "resistance": 23.04,
+        "reactance": 230.4,
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 100.0,
+        "isInterconnection": false
+      },
+      {
+        "id": "2",
+        "acBusOrigin": "1",
+        "acBusExtremity": "4",
+        "isTransmission": true,
+        "susceptance": 0.002893518518518519,
+        "voltageTapRatio": 1.0,
+        "ratedApparentPower": [
+          80.0,
+          80.0,
+          80.0
+        ],
+        "maxAngleDifference": 1.0471975511965976,
+        "minAngleDifference": -1.0471975511965976,
+        "resistance": 34.56,
+        "reactance": 345.59999999999997,
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 80.0,
+        "isInterconnection": false
+      },
+      {
+        "id": "3",
+        "acBusOrigin": "2",
+        "acBusExtremity": "3",
+        "isTransmission": true,
+        "susceptance": 0.008680555555555556,
+        "voltageTapRatio": 1.0,
+        "ratedApparentPower": [
+          50.0,
+          50.0,
+          50.0
+        ],
+        "maxAngleDifference": 1.0471975511965976,
+        "minAngleDifference": -1.0471975511965976,
+        "resistance": 11.52,
+        "reactance": 115.2,
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 50.0,
+        "isInterconnection": false
+      }
+    ],
+    "transformers": [],
+    "dcBranches": [
+      {
+        "id": "1",
+        "dcBusOrigin": "1",
+        "dcBusExtremity": "3",
+        "ratedActivePower": [
+          100.0,
+          100.0,
+          100.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 0.0,
+        "isInterconnection": false
+      },
+      {
+        "id": "2",
+        "dcBusOrigin": "2",
+        "dcBusExtremity": "4",
+        "ratedActivePower": [
+          100.0,
+          100.0,
+          100.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 0.0,
+        "isInterconnection": false
+      }
+    ],
+    "converters": [
+      {
+        "id": "4",
+        "acBusConnected": "3",
+        "dcBusConnected": "4",
+        "auxiliaryLosses": [
+          1.1033,
+          1.1033,
+          1.1033
+        ],
+        "linearLosses": [
+          0.001600342777409994,
+          0.001600342777409994,
+          0.001600342777409994
+        ],
+        "ratedActivePowerAC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "ratedActivePowerDC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 0
+      },
+      {
+        "id": "1",
+        "acBusConnected": "5",
+        "dcBusConnected": "1",
+        "auxiliaryLosses": [
+          1.1033,
+          1.1033,
+          1.1033
+        ],
+        "linearLosses": [
+          0.001600342777409994,
+          0.001600342777409994,
+          0.001600342777409994
+        ],
+        "ratedActivePowerAC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "ratedActivePowerDC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 0
+      },
+      {
+        "id": "2",
+        "acBusConnected": "5",
+        "dcBusConnected": "2",
+        "auxiliaryLosses": [
+          1.1033,
+          1.1033,
+          1.1033
+        ],
+        "linearLosses": [
+          0.001600342777409994,
+          0.001600342777409994,
+          0.001600342777409994
+        ],
+        "ratedActivePowerAC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "ratedActivePowerDC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 0
+      },
+      {
+        "id": "3",
+        "acBusConnected": "1",
+        "dcBusConnected": "3",
+        "auxiliaryLosses": [
+          1.1033,
+          1.1033,
+          1.1033
+        ],
+        "linearLosses": [
+          0.001600342777409994,
+          0.001600342777409994,
+          0.001600342777409994
+        ],
+        "ratedActivePowerAC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "ratedActivePowerDC": [
+          110.00000000000001,
+          110.00000000000001,
+          110.00000000000001
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "emergencyRating": 0
+      }
+    ],
+    "storage": [
+      {
+        "id": "1",
+        "acBusConnected": "5",
+        "maxEnergy": [
+          1000.0,
+          1000.0,
+          1000.0
+        ],
+        "selfDischargeRate": [
+          0.0001,
+          0.0001,
+          0.0001
+        ],
+        "minEnergy": [
+          0,
+          0,
+          0
+        ],
+        "maxEnergyYear": [
+          2400.0,
+          2400.0,
+          2400.0
+        ],
+        "absEfficiency": [
+          0.9,
+          0.9,
+          0.9
+        ],
+        "injEfficiency": [
+          0.9,
+          0.9,
+          0.9
+        ],
+        "maxReactivePowerExchange": [
+          70.0,
+          70.0,
+          70.0
+        ],
+        "minReactivePowerExchange": [
+          -50.0,
+          -50.0,
+          -50.0
+        ],
+        "maxAbsRamp": [
+          200.0,
+          200.0,
+          200.0
+        ],
+        "maxInjRamp": [
+          250.0,
+          250.0,
+          250.0
+        ],
+        "maxAbsActivePower": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "maxInjActivePower": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      }
+    ],
+    "generators": [
+      {
+        "id": "4",
+        "acBusConnected": "6",
+        "maxActivePower": [
+          120.0,
+          120.0,
+          120.0
+        ],
+        "minActivePower": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "maxReactivePower": [
+          183.0,
+          183.0,
+          183.0
+        ],
+        "minReactivePower": [
+          -10.0,
+          -10.0,
+          -10.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "generationCosts": [
+          108624.0,
+          108624.0,
+          108624.0
+        ],
+        "curtailmentCosts": [
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "id": "1",
+        "acBusConnected": "1",
+        "maxActivePower": [
+          150.0,
+          150.0,
+          150.0
+        ],
+        "minActivePower": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "maxReactivePower": [
+          48.0,
+          48.0,
+          48.0
+        ],
+        "minReactivePower": [
+          -10.0,
+          -10.0,
+          -10.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "generationCosts": [
+          108624.0,
+          108624.0,
+          108624.0
+        ],
+        "curtailmentCosts": [
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "id": "5",
+        "acBusConnected": "6",
+        "maxActivePower": [
+          240.0,
+          240.0,
+          240.0
+        ],
+        "minActivePower": [
+          240.0,
+          240.0,
+          240.0
+        ],
+        "maxReactivePower": [
+          183.0,
+          183.0,
+          183.0
+        ],
+        "minReactivePower": [
+          -10.0,
+          -10.0,
+          -10.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "generationCosts": [
+          84534.0,
+          84534.0,
+          84534.0
+        ],
+        "curtailmentCosts": [
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "id": "2",
+        "acBusConnected": "3",
+        "maxActivePower": [
+          180.0,
+          180.0,
+          180.0
+        ],
+        "minActivePower": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "maxReactivePower": [
+          101.0,
+          101.0,
+          101.0
+        ],
+        "minReactivePower": [
+          -10.0,
+          -10.0,
+          -10.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "generationCosts": [
+          206079.0,
+          206079.0,
+          206079.0
+        ],
+        "curtailmentCosts": [
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "id": "6",
+        "acBusConnected": "6",
+        "maxActivePower": [
+          240.0,
+          240.0,
+          240.0
+        ],
+        "minActivePower": [
+          240.0,
+          240.0,
+          240.0
+        ],
+        "maxReactivePower": [
+          183.0,
+          183.0,
+          183.0
+        ],
+        "minReactivePower": [
+          -10.0,
+          -10.0,
+          -10.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "generationCosts": [
+          93732.0,
+          93732.0,
+          93732.0
+        ],
+        "curtailmentCosts": [
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "id": "3",
+        "acBusConnected": "3",
+        "maxActivePower": [
+          180.0,
+          180.0,
+          180.0
+        ],
+        "minActivePower": [
+          180.0,
+          180.0,
+          180.0
+        ],
+        "maxReactivePower": [
+          101.0,
+          101.0,
+          101.0
+        ],
+        "minReactivePower": [
+          -10.0,
+          -10.0,
+          -10.0
+        ],
+        "meanTimeToRepair": 1,
+        "failureRate": 1,
+        "generationCosts": [
+          84534.0,
+          84534.0,
+          84534.0
+        ],
+        "curtailmentCosts": [
+          0,
+          0,
+          0
+        ]
+      }
+    ],
+    "loads": [
+      {
+        "id": "4",
+        "acBusConnected": "4",
+        "powerFactor": 1,
+        "gracePeriodUDS": [
+          10,
+          10,
+          10
+        ],
+        "gracePeriodDDS": [
+          10,
+          10,
+          10
+        ],
+        "maxEnergyNotConsumed": [
+          0.33455960759223713,
+          0.33455960759223713,
+          0.33455960759223713
+        ],
+        "valueOfLossLoad": [
+          21900000.0,
+          21900000.0,
+          21900000.0
+        ],
+        "compensationDemandShift": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "compensationConsumeLess": [
+          219.0,
+          219.0,
+          219.0
+        ],
+        "superiorBoundNCP": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundUDS": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundDDS": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "maxEnergyShifted": [
+          1,
+          1,
+          1
+        ],
+        "isFlexible": true
+      },
+      {
+        "id": "1",
+        "acBusConnected": "1",
+        "powerFactor": 1,
+        "gracePeriodUDS": [
+          10,
+          10,
+          10
+        ],
+        "gracePeriodDDS": [
+          10,
+          10,
+          10
+        ],
+        "maxEnergyNotConsumed": [
+          0.9177207579838399,
+          0.9177207579838399,
+          0.9177207579838399
+        ],
+        "valueOfLossLoad": [
+          21900000.0,
+          21900000.0,
+          21900000.0
+        ],
+        "compensationDemandShift": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "compensationConsumeLess": [
+          219.0,
+          219.0,
+          219.0
+        ],
+        "superiorBoundNCP": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundUDS": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundDDS": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "maxEnergyShifted": [
+          1,
+          1,
+          1
+        ],
+        "isFlexible": true
+      },
+      {
+        "id": "5",
+        "acBusConnected": "5",
+        "powerFactor": 1,
+        "gracePeriodUDS": [
+          10,
+          10,
+          10
+        ],
+        "gracePeriodDDS": [
+          10,
+          10,
+          10
+        ],
+        "maxEnergyNotConsumed": [
+          0.22857624831309045,
+          0.22857624831309045,
+          0.22857624831309045
+        ],
+        "valueOfLossLoad": [
+          21900000.0,
+          21900000.0,
+          21900000.0
+        ],
+        "compensationDemandShift": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "compensationConsumeLess": [
+          219.0,
+          219.0,
+          219.0
+        ],
+        "superiorBoundNCP": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundUDS": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundDDS": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "maxEnergyShifted": [
+          1,
+          1,
+          1
+        ],
+        "isFlexible": true
+      },
+      {
+        "id": "2",
+        "acBusConnected": "2",
+        "powerFactor": 1,
+        "gracePeriodUDS": [
+          10,
+          10,
+          10
+        ],
+        "gracePeriodDDS": [
+          10,
+          10,
+          10
+        ],
+        "maxEnergyNotConsumed": [
+          0.28991308325709064,
+          0.28991308325709064,
+          0.28991308325709064
+        ],
+        "valueOfLossLoad": [
+          21900000.0,
+          21900000.0,
+          21900000.0
+        ],
+        "compensationDemandShift": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "compensationConsumeLess": [
+          219.0,
+          219.0,
+          219.0
+        ],
+        "superiorBoundNCP": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundUDS": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundDDS": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "maxEnergyShifted": [
+          1,
+          1,
+          1
+        ],
+        "isFlexible": true
+      },
+      {
+        "id": "3",
+        "acBusConnected": "3",
+        "powerFactor": 1,
+        "gracePeriodUDS": [
+          10,
+          10,
+          10
+        ],
+        "gracePeriodDDS": [
+          10,
+          10,
+          10
+        ],
+        "maxEnergyNotConsumed": [
+          1,
+          1,
+          1
+        ],
+        "valueOfLossLoad": [
+          21900000.0,
+          21900000.0,
+          21900000.0
+        ],
+        "compensationDemandShift": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "compensationConsumeLess": [
+          219.0,
+          219.0,
+          219.0
+        ],
+        "superiorBoundNCP": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundUDS": [
+          0.3,
+          0.3,
+          0.3
+        ],
+        "superiorBoundDDS": [
+          1.0,
+          1.0,
+          1.0
+        ],
+        "maxEnergyShifted": [
+          1,
+          1,
+          1
+        ],
+        "isFlexible": true
+      }
+    ],
+    "psts": []
+  },
+  "scenarioDataInputFile": {
+    "storage": [
+      {
+        "id": "1",
+        "initEnergy": [
+          [
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "finalEnergy": [
+          [
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0
+          ]
+        ]
+      }
+    ],
+    "loads": [
+      {
+        "id": "4",
+        "demandReference": [
+          [
+            [
+              77.54581673306772,
+              77.38645418326693,
+              72.79681274900399,
+              71.17131474103586
+            ],
+            [
+              77.54581673306772,
+              77.38645418326693,
+              72.79681274900399,
+              71.17131474103586
+            ],
+            [
+              77.54581673306772,
+              77.38645418326693,
+              72.79681274900399,
+              71.17131474103586
+            ]
+          ],
+          [
+            [
+              84.41333882256073,
+              83.06298888431454,
+              77.99094277480445,
+              71.99670646356525
+            ],
+            [
+              84.41333882256073,
+              83.06298888431454,
+              77.99094277480445,
+              71.99670646356525
+            ],
+            [
+              84.41333882256073,
+              83.06298888431454,
+              77.99094277480445,
+              71.99670646356525
+            ]
+          ]
+        ]
+      },
+      {
+        "id": "1",
+        "demandReference": [
+          [
+            [
+              29.033737307566327,
+              28.197838191942353,
+              26.53914182771045,
+              25.19489027186374
+            ],
+            [
+              29.033737307566327,
+              28.197838191942353,
+              26.53914182771045,
+              25.19489027186374
+            ],
+            [
+              29.033737307566327,
+              28.197838191942353,
+              26.53914182771045,
+              25.19489027186374
+            ]
+          ],
+          [
+            [
+              29.413568417018016,
+              28.207486904305608,
+              26.651335122013542,
+              25.069630765299607
+            ],
+            [
+              29.413568417018016,
+              28.207486904305608,
+              26.651335122013542,
+              25.069630765299607
+            ],
+            [
+              29.413568417018016,
+              28.207486904305608,
+              26.651335122013542,
+              25.069630765299607
+            ]
+          ]
+        ]
+      },
+      {
+        "id": "5",
+        "demandReference": [
+          [
+            [
+              116.16236162361623,
+              111.88191881918819,
+              107.74907749077491,
+              101.69741697416974
+            ],
+            [
+              116.16236162361623,
+              111.88191881918819,
+              107.74907749077491,
+              101.69741697416974
+            ],
+            [
+              116.16236162361623,
+              111.88191881918819,
+              107.74907749077491,
+              101.69741697416974
+            ]
+          ],
+          [
+            [
+              139.54198473282443,
+              139.54198473282443,
+              135.1145038167939,
+              129.9236641221374
+            ],
+            [
+              139.54198473282443,
+              139.54198473282443,
+              135.1145038167939,
+              129.9236641221374
+            ],
+            [
+              139.54198473282443,
+              139.54198473282443,
+              135.1145038167939,
+              129.9236641221374
+            ]
+          ]
+        ]
+      },
+      {
+        "id": "2",
+        "demandReference": [
+          [
+            [
+              93.76725838264299,
+              89.1913214990138,
+              83.66863905325444,
+              78.30374753451676
+            ],
+            [
+              93.76725838264299,
+              89.1913214990138,
+              83.66863905325444,
+              78.30374753451676
+            ],
+            [
+              93.76725838264299,
+              89.1913214990138,
+              83.66863905325444,
+              78.30374753451676
+            ]
+          ],
+          [
+            [
+              101.19178768152229,
+              97.2258387581372,
+              94.78217325988982,
+              90.37556334501751
+            ],
+            [
+              101.19178768152229,
+              97.2258387581372,
+              94.78217325988982,
+              90.37556334501751
+            ],
+            [
+              101.19178768152229,
+              97.2258387581372,
+              94.78217325988982,
+              90.37556334501751
+            ]
+          ]
+        ]
+      },
+      {
+        "id": "3",
+        "demandReference": [
+          [
+            [
+              22.331008243500317,
+              21.666455294863667,
+              20.2714013950539,
+              18.932149651236525
+            ],
+            [
+              22.331008243500317,
+              21.666455294863667,
+              20.2714013950539,
+              18.932149651236525
+            ],
+            [
+              22.331008243500317,
+              21.666455294863667,
+              20.2714013950539,
+              18.932149651236525
+            ]
+          ],
+          [
+            [
+              20.054315739756763,
+              19.364742000236156,
+              18.07061046168379,
+              16.69146298264258
+            ],
+            [
+              20.054315739756763,
+              19.364742000236156,
+              18.07061046168379,
+              16.69146298264258
+            ],
+            [
+              20.054315739756763,
+              19.364742000236156,
+              18.07061046168379,
+              16.69146298264258
+            ]
+          ]
+        ]
+      }
+    ],
+    "generators": [
+      {
+        "id": "4"
+      },
+      {
+        "id": "1"
+      },
+      {
+        "id": "5",
+        "capacityFactor": [
+          [
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          ],
+          [
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          ]
+        ]
+      },
+      {
+        "id": "2"
+      },
+      {
+        "id": "6",
+        "capacityFactor": [
+          [
+            [
+              0.021,
+              0.022,
+              0.026,
+              0.034
+            ],
+            [
+              0.021,
+              0.022,
+              0.026,
+              0.034
+            ],
+            [
+              0.021,
+              0.022,
+              0.026,
+              0.034
+            ]
+          ],
+          [
+            [
+              0.543,
+              0.516,
+              0.52,
+              0.49300000000000005
+            ],
+            [
+              0.543,
+              0.516,
+              0.52,
+              0.49300000000000005
+            ],
+            [
+              0.543,
+              0.516,
+              0.52,
+              0.49300000000000005
+            ]
+          ]
+        ]
+      },
+      {
+        "id": "3",
+        "capacityFactor": [
+          [
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          ],
+          [
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          ]
+        ]
+      }
+    ]
+  },
+  "candidatesInputFile": {
+    "acBranches": [
+      {
+        "acBranch": {
+          "id": "C4",
+          "acBusOrigin": "2",
+          "acBusExtremity": "3",
+          "isTransmission": true,
+          "susceptance": 0.004340277777777778,
+          "voltageTapRatio": 1.0,
+          "ratedApparentPower": [
+            100.0,
+            100.0,
+            100.0
+          ],
+          "maxAngleDifference": 1.0471975511965976,
+          "minAngleDifference": -1.0471975511965976,
+          "resistance": 23.04,
+          "reactance": 230.4,
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 100.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          127000000.0,
+          85796649.44087642,
+          57961142.1675641
+        ],
+        "lifetime": 30,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "acBranch": {
+          "id": "C1",
+          "acBusOrigin": "1",
+          "acBusExtremity": "3",
+          "isTransmission": true,
+          "susceptance": 0.008680555555555556,
+          "voltageTapRatio": 1.0,
+          "ratedApparentPower": [
+            100.0,
+            100.0,
+            100.0
+          ],
+          "maxAngleDifference": 1.0471975511965976,
+          "minAngleDifference": -1.0471975511965976,
+          "resistance": 11.52,
+          "reactance": 115.2,
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 100.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          62500000.0,
+          42222760.551612414,
+          28524184.13758076
+        ],
+        "lifetime": 30,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "acBranch": {
+          "id": "C2",
+          "acBusOrigin": "3",
+          "acBusExtremity": "4",
+          "isTransmission": true,
+          "susceptance": 0.008680555555555556,
+          "voltageTapRatio": 1.0,
+          "ratedApparentPower": [
+            100.0,
+            100.0,
+            100.0
+          ],
+          "maxAngleDifference": 1.0471975511965976,
+          "minAngleDifference": -1.0471975511965976,
+          "resistance": 11.52,
+          "reactance": 115.2,
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 100.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          61750000.0,
+          41716087.42499307,
+          28181893.927929793
+        ],
+        "lifetime": 30,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "acBranch": {
+          "id": "C3",
+          "acBusOrigin": "4",
+          "acBusExtremity": "6",
+          "isTransmission": true,
+          "susceptance": 0.008680555555555556,
+          "voltageTapRatio": 1.0,
+          "ratedApparentPower": [
+            100.0,
+            100.0,
+            100.0
+          ],
+          "maxAngleDifference": 1.0471975511965976,
+          "minAngleDifference": -1.0471975511965976,
+          "resistance": 11.52,
+          "reactance": 115.2,
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 100.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          147000000.0,
+          99307932.8173924,
+          67088881.09158995
+        ],
+        "lifetime": 30,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      }
+    ],
+    "transformers": [],
+    "dcBranches": [
+      {
+        "dcBranch": {
+          "id": "C1",
+          "dcBusOrigin": "5",
+          "dcBusExtremity": "6",
+          "ratedActivePower": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          222750000.125,
+          150481918.69039217,
+          101660192.32338619
+        ],
+        "lifetime": 20,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "dcBranch": {
+          "id": "C2",
+          "dcBusOrigin": "5",
+          "dcBusExtremity": "7",
+          "ratedActivePower": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          177550000.125,
+          119946418.25946607,
+          81031502.35508779
+        ],
+        "lifetime": 20,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "dcBranch": {
+          "id": "C3",
+          "dcBusOrigin": "5",
+          "dcBusExtremity": "8",
+          "ratedActivePower": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0.0,
+          "isInterconnection": false
+        },
+        "invCost": [
+          244350000.125,
+          165074104.7370294,
+          111518150.36133412
+        ],
+        "lifetime": 20,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      }
+    ],
+    "converters": [
+      {
+        "converter": {
+          "id": "C4",
+          "acBusConnected": "3",
+          "dcBusConnected": "6",
+          "auxiliaryLosses": [
+            1.1033,
+            1.1033,
+            1.1033
+          ],
+          "linearLosses": [
+            0.0017070322959039934,
+            0.0017070322959039934,
+            0.0017070322959039934
+          ],
+          "ratedActivePowerAC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "ratedActivePowerDC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0
+        },
+        "invCost": [
+          10000000.125,
+          6755641.772703507,
+          4563869.51906129
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "converter": {
+          "id": "C1",
+          "acBusConnected": "6",
+          "dcBusConnected": "5",
+          "auxiliaryLosses": [
+            1.1033,
+            1.1033,
+            1.1033
+          ],
+          "linearLosses": [
+            0.001600342777409994,
+            0.001600342777409994,
+            0.001600342777409994
+          ],
+          "ratedActivePowerAC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "ratedActivePowerDC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0
+        },
+        "invCost": [
+          10000000.125,
+          6755641.772703507,
+          4563869.51906129
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "converter": {
+          "id": "C5",
+          "acBusConnected": "4",
+          "dcBusConnected": "7",
+          "auxiliaryLosses": [
+            1.1033,
+            1.1033,
+            1.1033
+          ],
+          "linearLosses": [
+            0.001600342777409994,
+            0.001600342777409994,
+            0.001600342777409994
+          ],
+          "ratedActivePowerAC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "ratedActivePowerDC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0
+        },
+        "invCost": [
+          10000000.125,
+          6755641.772703507,
+          4563869.51906129
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "converter": {
+          "id": "C2",
+          "acBusConnected": "6",
+          "dcBusConnected": "5",
+          "auxiliaryLosses": [
+            1.1033,
+            1.1033,
+            1.1033
+          ],
+          "linearLosses": [
+            0.001600342777409994,
+            0.001600342777409994,
+            0.001600342777409994
+          ],
+          "ratedActivePowerAC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "ratedActivePowerDC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0
+        },
+        "invCost": [
+          10000000.125,
+          6755641.772703507,
+          4563869.51906129
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "converter": {
+          "id": "C6",
+          "acBusConnected": "5",
+          "dcBusConnected": "8",
+          "auxiliaryLosses": [
+            1.1033,
+            1.1033,
+            1.1033
+          ],
+          "linearLosses": [
+            0.001600342777409994,
+            0.001600342777409994,
+            0.001600342777409994
+          ],
+          "ratedActivePowerAC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "ratedActivePowerDC": [
+            330.0,
+            330.0,
+            330.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0
+        },
+        "invCost": [
+          10000000.125,
+          6755641.772703507,
+          4563869.51906129
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "converter": {
+          "id": "C3",
+          "acBusConnected": "6",
+          "dcBusConnected": "5",
+          "auxiliaryLosses": [
+            1.1033,
+            1.1033,
+            1.1033
+          ],
+          "linearLosses": [
+            0.001600342777409994,
+            0.001600342777409994,
+            0.001600342777409994
+          ],
+          "ratedActivePowerAC": [
+            660.0,
+            660.0,
+            660.0
+          ],
+          "ratedActivePowerDC": [
+            660.0,
+            660.0,
+            660.0
+          ],
+          "meanTimeToRepair": 1,
+          "failureRate": 1,
+          "emergencyRating": 0
+        },
+        "invCost": [
+          20000000.125,
+          13511283.460961493,
+          9127738.981074212
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      }
+    ],
+    "storage": [
+      {
+        "storage": {
+          "id": "C1",
+          "acBusConnected": "2",
+          "maxEnergy": [
+            1000.0,
+            1000.0,
+            1000.0
+          ],
+          "selfDischargeRate": [
+            0.001,
+            0.001,
+            0.001
+          ],
+          "minEnergy": [
+            0,
+            0,
+            0
+          ],
+          "maxEnergyYear": [
+            2400.0,
+            2400.0,
+            2400.0
+          ],
+          "absEfficiency": [
+            0.9,
+            0.9,
+            0.9
+          ],
+          "injEfficiency": [
+            0.9,
+            0.9,
+            0.9
+          ],
+          "maxReactivePowerExchange": [
+            70.0,
+            70.0,
+            70.0
+          ],
+          "minReactivePowerExchange": [
+            -50.0,
+            -50.0,
+            -50.0
+          ],
+          "maxAbsRamp": [
+            200.0,
+            200.0,
+            200.0
+          ],
+          "maxInjRamp": [
+            250.0,
+            250.0,
+            250.0
+          ],
+          "maxAbsActivePower": [
+            200.0,
+            200.0,
+            200.0
+          ],
+          "maxInjActivePower": [
+            250.0,
+            250.0,
+            250.0
+          ]
+        },
+        "invCost": [
+          75000000.25,
+          50667312.83082594,
+          34229021.07919365
+        ],
+        "storageData": {
+          "id": "C1",
+          "initEnergy": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ],
+          "finalEnergy": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        "lifetime": 10,
+        "isUnique": false,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "storage": {
+          "id": "C2",
+          "acBusConnected": "5",
+          "maxEnergy": [
+            1000.0,
+            1000.0,
+            1000.0
+          ],
+          "selfDischargeRate": [
+            0.001,
+            0.001,
+            0.001
+          ],
+          "minEnergy": [
+            0,
+            0,
+            0
+          ],
+          "maxEnergyYear": [
+            2400.0,
+            2400.0,
+            2400.0
+          ],
+          "absEfficiency": [
+            0.9,
+            0.9,
+            0.9
+          ],
+          "injEfficiency": [
+            0.9,
+            0.9,
+            0.9
+          ],
+          "maxReactivePowerExchange": [
+            70.0,
+            70.0,
+            70.0
+          ],
+          "minReactivePowerExchange": [
+            -50.0,
+            -50.0,
+            -50.0
+          ],
+          "maxAbsRamp": [
+            200.0,
+            200.0,
+            200.0
+          ],
+          "maxInjRamp": [
+            250.0,
+            250.0,
+            250.0
+          ],
+          "maxAbsActivePower": [
+            200.0,
+            200.0,
+            200.0
+          ],
+          "maxInjActivePower": [
+            250.0,
+            250.0,
+            250.0
+          ]
+        },
+        "invCost": [
+          75000000.25,
+          50667312.83082594,
+          34229021.07919365
+        ],
+        "storageData": {
+          "id": "C2",
+          "initEnergy": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ],
+          "finalEnergy": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        "lifetime": 10,
+        "isUnique": false,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      }
+    ],
+    "flexibleLoads": [
+      {
+        "load": {
+          "id": "4",
+          "acBusConnected": "4",
+          "powerFactor": 1,
+          "gracePeriodUDS": [
+            10,
+            10,
+            10
+          ],
+          "gracePeriodDDS": [
+            10,
+            10,
+            10
+          ],
+          "maxEnergyNotConsumed": [
+            0.33455960759223713,
+            0.33455960759223713,
+            0.33455960759223713
+          ],
+          "valueOfLossLoad": [
+            21900000.0,
+            21900000.0,
+            21900000.0
+          ],
+          "compensationDemandShift": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "compensationConsumeLess": [
+            219.0,
+            219.0,
+            219.0
+          ],
+          "superiorBoundNCP": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundUDS": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundDDS": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "maxEnergyShifted": [
+            1,
+            1,
+            1
+          ]
+        },
+        "invCost": [
+          40000.125,
+          27022.65119855305,
+          18255.534896419962
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "load": {
+          "id": "1",
+          "acBusConnected": "1",
+          "powerFactor": 1,
+          "gracePeriodUDS": [
+            10,
+            10,
+            10
+          ],
+          "gracePeriodDDS": [
+            10,
+            10,
+            10
+          ],
+          "maxEnergyNotConsumed": [
+            0.9177207579838399,
+            0.9177207579838399,
+            0.9177207579838399
+          ],
+          "valueOfLossLoad": [
+            21900000.0,
+            21900000.0,
+            21900000.0
+          ],
+          "compensationDemandShift": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "compensationConsumeLess": [
+            219.0,
+            219.0,
+            219.0
+          ],
+          "superiorBoundNCP": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundUDS": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundDDS": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "maxEnergyShifted": [
+            1,
+            1,
+            1
+          ]
+        },
+        "invCost": [
+          20000.125,
+          13511.367822037075,
+          9127.795972394119
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "load": {
+          "id": "5",
+          "acBusConnected": "5",
+          "powerFactor": 1,
+          "gracePeriodUDS": [
+            10,
+            10,
+            10
+          ],
+          "gracePeriodDDS": [
+            10,
+            10,
+            10
+          ],
+          "maxEnergyNotConsumed": [
+            0.22857624831309045,
+            0.22857624831309045,
+            0.22857624831309045
+          ],
+          "valueOfLossLoad": [
+            21900000.0,
+            21900000.0,
+            21900000.0
+          ],
+          "compensationDemandShift": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "compensationConsumeLess": [
+            219.0,
+            219.0,
+            219.0
+          ],
+          "superiorBoundNCP": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundUDS": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundDDS": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "maxEnergyShifted": [
+            1,
+            1,
+            1
+          ]
+        },
+        "invCost": [
+          60000.125,
+          40533.93457506902,
+          27383.273820445804
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "load": {
+          "id": "2",
+          "acBusConnected": "2",
+          "powerFactor": 1,
+          "gracePeriodUDS": [
+            10,
+            10,
+            10
+          ],
+          "gracePeriodDDS": [
+            10,
+            10,
+            10
+          ],
+          "maxEnergyNotConsumed": [
+            0.28991308325709064,
+            0.28991308325709064,
+            0.28991308325709064
+          ],
+          "valueOfLossLoad": [
+            21900000.0,
+            21900000.0,
+            21900000.0
+          ],
+          "compensationDemandShift": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "compensationConsumeLess": [
+            219.0,
+            219.0,
+            219.0
+          ],
+          "superiorBoundNCP": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundUDS": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundDDS": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "maxEnergyShifted": [
+            1,
+            1,
+            1
+          ]
+        },
+        "invCost": [
+          60000.125,
+          40533.93457506902,
+          27383.273820445804
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      },
+      {
+        "load": {
+          "id": "3",
+          "acBusConnected": "3",
+          "powerFactor": 1,
+          "gracePeriodUDS": [
+            10,
+            10,
+            10
+          ],
+          "gracePeriodDDS": [
+            10,
+            10,
+            10
+          ],
+          "maxEnergyNotConsumed": [
+            1,
+            1,
+            1
+          ],
+          "valueOfLossLoad": [
+            21900000.0,
+            21900000.0,
+            21900000.0
+          ],
+          "compensationDemandShift": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "compensationConsumeLess": [
+            219.0,
+            219.0,
+            219.0
+          ],
+          "superiorBoundNCP": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundUDS": [
+            0.3,
+            0.3,
+            0.3
+          ],
+          "superiorBoundDDS": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "maxEnergyShifted": [
+            1,
+            1,
+            1
+          ]
+        },
+        "invCost": [
+          10000.125,
+          6755.72613377909,
+          4563.926510381197
+        ],
+        "lifetime": 40,
+        "isUnique": true,
+        "horizons": [
+          2030,
+          2040,
+          2050
+        ]
+      }
+    ],
+    "psts": []
+  }
+}

--- a/test/scripts/test_json_converter.jl
+++ b/test/scripts/test_json_converter.jl
@@ -1,0 +1,47 @@
+# Test the JSON converter functionality
+
+## Import packages
+
+import PowerModels; const _PM = PowerModels
+import PowerModelsACDC; const _PMACDC = PowerModelsACDC
+import FlexPlan; const _FP = FlexPlan
+import Cbc
+optimizer = _FP.optimizer_with_attributes(Cbc.Optimizer, # Options: <https://github.com/jump-dev/Cbc.jl#options>
+    "logLevel" => 0,
+)
+
+
+## Script parameters
+
+file = "test/data/json_converter/case6_input_file_2018-2019.json"
+
+
+## Parse the JSON file to easily check the input
+
+#import JSON
+#d = JSON.parsefile(file)
+
+
+## Convert JSON file
+
+mn_data = _FP.convert_JSON(file) # Conversion caveats and function parameters: see function documentation
+
+
+## Instantiate model and solve network expansion problem
+
+# Transmission network
+
+result = _FP.stoch_flex_tnep(mn_data, _PM.DCPPowerModel, optimizer)
+# Two-step alternative: exposes `pm`
+#pm = _PM.instantiate_model(mn_data, _PM.DCPPowerModel, _FP.post_stoch_flex_tnep; ref_extensions=[_PMACDC.add_ref_dcgrid!, _PMACDC.add_candidate_dcgrid!, _FP.add_candidate_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _PM.ref_add_ne_branch!])
+#result = _PM.optimize_model!(pm; optimizer=optimizer)
+
+# Distribution network
+
+#result = _FP.stoch_flex_tnep(mn_data, _FP.BFARadPowerModel, optimizer)
+# Two-step alternative: exposes `pm`
+#pm = _PM.instantiate_model(mn_data, _FP.BFARadPowerModel, _FP.post_stoch_flex_tnep; ref_extensions=[_FP.add_candidate_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _FP.ref_add_ne_branch_allbranches!, _FP.ref_add_frb_branch!, _FP.ref_add_oltc_branch!])
+#result = _PM.optimize_model!(pm; optimizer=optimizer, solution_processors=[_PM.sol_data_model!])
+
+
+println("Test completed")


### PR DESCRIPTION
Use `FlexPlan.convert_JSON` to convert a JSON file or a dict conforming to the FlexPlan WP3 API into a FlexPlan.jl dict.
Type `??FlexPlan.convert_JSON` in the REPL to read about the conversion limitations and some caveats.

Test script: `test/scripts/test_json_converter.jl`.