### PR TITLE
Prepare release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Memento = "~1.0, ~1.1, ~1.2, ~1.3"
 PowerModels = "0.19.1"
 PowerModelsACDC = "=0.5.2"
 SCS = ">= 0.8"
-julia = "^1"
+julia = "1.5"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "FlexPlan"
 uuid = "4dc3fedf-fcb4-4327-bce2-523fd266e8c9"
 autors = ["Hakan Ergun", "Matteo Rossini", "Marco Rossi", "Damien Lapage", "Iver Bakken Sperstad", "Espen Flo Bødal", "Merkebu Zenebe Degefa", "Reinhilde D'hulst"]
 repo = "https://github.com/electa-git/FlexPlan.jl"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"

--- a/examples/example_stochastic_tnep.jl
+++ b/examples/example_stochastic_tnep.jl
@@ -23,12 +23,12 @@ import JSON
 import CSV
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 ################# INPUT PARAMETERS ######################
 number_of_hours = 144 # Number of time points

--- a/src/FlexPlan.jl
+++ b/src/FlexPlan.jl
@@ -15,8 +15,8 @@ const _IM = InfrastructureModels
 import MathOptInterface
 const _MOI = MathOptInterface
 
-import JuMP: with_optimizer, optimizer_with_attributes
-export with_optimizer, optimizer_with_attributes
+import JuMP: optimizer_with_attributes
+export optimizer_with_attributes
 
 using Printf
 

--- a/src/core/dimensions.jl
+++ b/src/core/dimensions.jl
@@ -94,7 +94,7 @@ function shift_ids!(data::Dict{String,Any}, offset::Int)
     if _IM.ismultinetwork(data)
         Memento.error(_LOGGER, "`shift_ids!` can only be applied to single-network data dictionaries.")
     end
-    shift_ids!(data["dim"], offset)
+    shift_ids!(dim(data), offset)
 end
 
 """
@@ -193,7 +193,7 @@ function require_dim(data::Dict{String,Any}, dimensions::Symbol...)
         Memento.error(_LOGGER, "Missing `dim` dict in `data`. Use `add_dimension!` to fix.")
     end
     for d in dimensions
-        if !haskey(data["dim"][:prop], d)
+        if !haskey(dim(data)[:prop], d)
             Memento.error(_LOGGER, "Missing dimension \"$d\" in `data`. Use `add_dimension!` to fix.")
         end
     end
@@ -231,11 +231,11 @@ function nw_ids(dim::Dict{Symbol,Any}; kwargs...)::Vector{Int}
 end
 
 function nw_ids(data::Dict{String,Any}; kwargs...)::Vector{Int}
-    haskey(data, "dim") ? nw_ids(data["dim"]; kwargs...) : [0]
+    haskey(data, "dim") ? nw_ids(dim(data); kwargs...) : [0]
 end
 
 function nw_ids(pm::_PM.AbstractPowerModel; kwargs...)::Vector{Int}
-    haskey(pm.ref[:it][:pm], :dim) ? nw_ids(pm.ref[:it][:pm][:dim]; kwargs...) : [0]
+    haskey(pm.ref[:it][_PM.pm_it_sym], :dim) ? nw_ids(dim(pm); kwargs...) : [0]
 end
 
 
@@ -270,8 +270,8 @@ function similar_ids(dim::Dict{Symbol,Any}, n::Int; kwargs...)::Vector{Int}
     ndims(nws) >= 1 ? vec(nws) : [nws]
 end
 
-similar_ids(data::Dict{String,Any}, n::Int; kwargs...) = similar_ids(data["dim"], n; kwargs...)
-similar_ids(pm::_PM.AbstractPowerModel, n::Int; kwargs...) = similar_ids(pm.ref[:it][:pm][:dim], n; kwargs...)
+similar_ids(data::Dict{String,Any}, n::Int; kwargs...) = similar_ids(dim(data), n; kwargs...)
+similar_ids(pm::_PM.AbstractPowerModel, n::Int; kwargs...) = similar_ids(dim(pm), n; kwargs...)
 
 """
     similar_id(pm::PowerModels.AbstractPowerModel, n::Int; kwargs...)
@@ -299,8 +299,8 @@ function similar_id(dim::Dict{Symbol,Any}, n::Int; kwargs...)::Int
     li[ntuple(i -> get(kwargs, names[i], ci_n[i])::Int, ndims(li))...]
 end
 
-similar_id(data::Dict{String,Any}, n::Int; kwargs...) = similar_id(data["dim"], n; kwargs...)
-similar_id(pm::_PM.AbstractPowerModel, n::Int; kwargs...) = similar_id(pm.ref[:it][:pm][:dim], n; kwargs...)
+similar_id(data::Dict{String,Any}, n::Int; kwargs...) = similar_id(dim(data), n; kwargs...)
+similar_id(pm::_PM.AbstractPowerModel, n::Int; kwargs...) = similar_id(dim(pm), n; kwargs...)
 
 """
     first_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol...)
@@ -319,8 +319,8 @@ function first_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
     li[ntuple(i -> names[i] in dimension ? 1 : ci_n[i], ndims(li))...]
 end
 
-first_id(data::Dict{String,Any}, n::Int, dimension::Symbol...) = first_id(data["dim"], n, dimension...)
-first_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...) = first_id(pm.ref[:it][:pm][:dim], n, dimension...)
+first_id(data::Dict{String,Any}, n::Int, dimension::Symbol...) = first_id(dim(data), n, dimension...)
+first_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...) = first_id(dim(pm), n, dimension...)
 
 """
     last_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol...)
@@ -339,8 +339,8 @@ function last_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
     li[ntuple(i -> names[i] in dimension ? size(li,i) : ci_n[i], ndims(li))...]
 end
 
-last_id(data::Dict{String,Any}, n::Int, dimension::Symbol...) = last_id(data["dim"], n, dimension...)
-last_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...) = last_id(pm.ref[:it][:pm][:dim], n, dimension...)
+last_id(data::Dict{String,Any}, n::Int, dimension::Symbol...) = last_id(dim(data), n, dimension...)
+last_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol...) = last_id(dim(pm), n, dimension...)
 
 """
     prev_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
@@ -359,8 +359,8 @@ function prev_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Int
     li[ntuple(i -> i == pos_d ? ci_n[i]-1 : ci_n[i], ndims(li))...]
 end
 
-prev_id(data::Dict{String,Any}, n::Int, dimension::Symbol) = prev_id(data["dim"], n, dimension)
-prev_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = prev_id(pm.ref[:it][:pm][:dim], n, dimension)
+prev_id(data::Dict{String,Any}, n::Int, dimension::Symbol) = prev_id(dim(data), n, dimension)
+prev_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = prev_id(dim(pm), n, dimension)
 
 """
     prev_ids(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
@@ -379,8 +379,8 @@ function prev_ids(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Vector{Int}
     li[CartesianIndex(ci_n[1:pos_d-1]), CartesianIndices((1:ci_n[pos_d]-1,)), CartesianIndex(ci_n[pos_d+1:end])]
 end
 
-prev_ids(data::Dict{String,Any}, n::Int, dimension::Symbol) = prev_ids(data["dim"], n, dimension)
-prev_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = prev_ids(pm.ref[:it][:pm][:dim], n, dimension)
+prev_ids(data::Dict{String,Any}, n::Int, dimension::Symbol) = prev_ids(dim(data), n, dimension)
+prev_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = prev_ids(dim(pm), n, dimension)
 
 """
     next_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
@@ -399,8 +399,8 @@ function next_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Int
     li[ntuple(i -> i == pos_d ? ci_n[i]+1 : ci_n[i], ndims(li))...]
 end
 
-next_id(data::Dict{String,Any}, n::Int, dimension::Symbol) = next_id(data["dim"], n, dimension)
-next_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = next_id(pm.ref[:it][:pm][:dim], n, dimension)
+next_id(data::Dict{String,Any}, n::Int, dimension::Symbol) = next_id(dim(data), n, dimension)
+next_id(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = next_id(dim(pm), n, dimension)
 
 """
     next_ids(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol)
@@ -419,8 +419,8 @@ function next_ids(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)::Vector{Int}
     li[CartesianIndex(ci_n[1:pos_d-1]), CartesianIndices((ci_n[pos_d]+1:size(li,pos_d),)), CartesianIndex(ci_n[pos_d+1:end])]
 end
 
-next_ids(data::Dict{String,Any}, n::Int, dimension::Symbol) = next_ids(data["dim"], n, dimension)
-next_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = next_ids(pm.ref[:it][:pm][:dim], n, dimension)
+next_ids(data::Dict{String,Any}, n::Int, dimension::Symbol) = next_ids(dim(data), n, dimension)
+next_ids(pm::_PM.AbstractPowerModel, n::Int, dimension::Symbol) = next_ids(dim(pm), n, dimension)
 
 
 ## Query properties of nw ids
@@ -441,8 +441,8 @@ function coord(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol)
     ci_n[pos[dimension]]
 end
 
-coord(data::Dict{String,Any}, args...) = coord(data["dim"], args...)
-coord(pm::_PM.AbstractPowerModel, args...) = coord(pm.ref[:it][:pm][:dim], args...)
+coord(data::Dict{String,Any}, args...) = coord(dim(data), args...)
+coord(pm::_PM.AbstractPowerModel, args...) = coord(dim(pm), args...)
 
 """
     is_first_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol...)
@@ -460,8 +460,8 @@ function is_first_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
     all(ci_n[pos[d]] == 1 for d in dimension)
 end
 
-is_first_id(data::Dict{String,Any}, args...) = is_first_id(data["dim"], args...)
-is_first_id(pm::_PM.AbstractPowerModel, args...) = is_first_id(pm.ref[:it][:pm][:dim], args...)
+is_first_id(data::Dict{String,Any}, args...) = is_first_id(dim(data), args...)
+is_first_id(pm::_PM.AbstractPowerModel, args...) = is_first_id(dim(pm), args...)
 
 """
     is_last_id(pm::PowerModels.AbstractPowerModel, n::Int, dimension::Symbol...)
@@ -478,11 +478,21 @@ function is_last_id(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol...)
     all(ci_n[pos[d]] == size(li,pos[d]) for d in dimension)
 end
 
-is_last_id(data::Dict{String,Any}, args...) = is_last_id(data["dim"], args...)
-is_last_id(pm::_PM.AbstractPowerModel, args...) = is_last_id(pm.ref[:it][:pm][:dim], args...)
+is_last_id(data::Dict{String,Any}, args...) = is_last_id(dim(data), args...)
+is_last_id(pm::_PM.AbstractPowerModel, args...) = is_last_id(dim(pm), args...)
 
 
 ## Access data relating to dimensions
+
+"""
+    dim(data::Dict{String,Any})
+    dim(pm::PowerModels.AbstractPowerModel)
+
+Return `dim` data structure.
+"""
+function dim end
+dim(data::Dict{String,Any}) = data["dim"]
+dim(pm::_PM.AbstractPowerModel) = pm.ref[:it][_PM.pm_it_sym][:dim]
 
 """
     dim_prop(dim::Dict{Symbol,Any}[, dimension[, id[, key]]])
@@ -506,8 +516,8 @@ dim_prop(dim::Dict{Symbol,Any}, dimension::Symbol, id::Int, key::String) = dim[:
 dim_prop(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol) = dim[:prop][dimension][coord(dim,n,dimension)]
 dim_prop(dim::Dict{Symbol,Any}, n::Int, dimension::Symbol, key::String) = dim[:prop][dimension][coord(dim,n,dimension)][key]
 
-dim_prop(data::Dict{String,Any}, args...) = dim_prop(data["dim"], args...)
-dim_prop(pm::_PM.AbstractPowerModel, args...) = dim_prop(pm.ref[:it][:pm][:dim], args...)
+dim_prop(data::Dict{String,Any}, args...) = dim_prop(dim(data), args...)
+dim_prop(pm::_PM.AbstractPowerModel, args...) = dim_prop(dim(pm), args...)
 
 """
     dim_meta(dim::Dict{Symbol,Any}[, dimension[, key]])
@@ -520,8 +530,8 @@ function dim_meta end
 dim_meta(dim::Dict{Symbol,Any}) = dim[:meta]
 dim_meta(dim::Dict{Symbol,Any}, dimension::Symbol) = dim[:meta][dimension]
 dim_meta(dim::Dict{Symbol,Any}, dimension::Symbol, key::String) = dim[:meta][dimension][key]
-dim_meta(data::Dict{String,Any}, args...) = dim_meta(data["dim"], args...)
-dim_meta(pm::_PM.AbstractPowerModel, args...) = dim_meta(pm.ref[:it][:pm][:dim], args...)
+dim_meta(data::Dict{String,Any}, args...) = dim_meta(dim(data), args...)
+dim_meta(pm::_PM.AbstractPowerModel, args...) = dim_meta(dim(pm), args...)
 
 """
     dim_length(dim::Dict{Symbol,Any}[, dimension])
@@ -533,5 +543,5 @@ Return the number of networks or, if `dimension` is specified, return its size.
 function dim_length end
 dim_length(dim::Dict{Symbol,Any}) = length(dim[:li])
 dim_length(dim::Dict{Symbol,Any}, dimension::Symbol) = size(dim[:li], dim[:pos][dimension])
-dim_length(data::Dict{String,Any}, args...) = dim_length(data["dim"], args...)
-dim_length(pm::_PM.AbstractPowerModel, args...) = dim_length(pm.ref[:it][:pm][:dim], args...)
+dim_length(data::Dict{String,Any}, args...) = dim_length(dim(data), args...)
+dim_length(pm::_PM.AbstractPowerModel, args...) = dim_length(dim(pm), args...)

--- a/src/core/distribution.jl
+++ b/src/core/distribution.jl
@@ -46,7 +46,7 @@ function variable_oltc_branch_transform_magnitude_sqr_inv(pm::_PM.AbstractPowerM
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :branch, :ttmi, _PM.ids(pm, nw, :oltc_branch), ttmi)
+    report && _PM.sol_component_value(pm, nw, :branch, :ttmi, _PM.ids(pm, nw, :oltc_branch), ttmi)
 end
 
 function variable_oltc_ne_branch_transform(pm::_PM.AbstractWModels; kwargs...)
@@ -68,7 +68,7 @@ function variable_oltc_ne_branch_transform_magnitude_sqr_inv(pm::_PM.AbstractPow
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_branch, :ttmi, _PM.ids(pm, nw, :oltc_ne_branch), ttmi_ne)
+    report && _PM.sol_component_value(pm, nw, :ne_branch, :ttmi, _PM.ids(pm, nw, :oltc_ne_branch), ttmi_ne)
 end
 
 

--- a/src/core/flexible_demand.jl
+++ b/src/core/flexible_demand.jl
@@ -36,7 +36,7 @@ function variable_flexible_demand_indicator(pm::_PM.AbstractPowerModel; nw::Int=
         z = _PM.var(pm, nw)[:z_flex] = _PM.var(pm, first_n)[:z_flex]
     end
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :flex, _PM.ids(pm, nw, :flex_load), z)
+        _PM.sol_component_value(pm, nw, :load, :flex, _PM.ids(pm, nw, :flex_load), z)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :flex, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -63,7 +63,7 @@ function variable_flexible_demand_investment(pm::_PM.AbstractPowerModel; nw::Int
         investment = _PM.var(pm, nw)[:z_flex_investment] = _PM.var(pm, first_n)[:z_flex_investment]
     end
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :investment, _PM.ids(pm, nw, :flex_load), investment)
+        _PM.sol_component_value(pm, nw, :load, :investment, _PM.ids(pm, nw, :flex_load), investment)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :investment, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -81,7 +81,7 @@ function variable_total_flex_demand_active(pm::_PM.AbstractPowerModel; nw::Int=_
         upper_bound = _PM.ref(pm, nw, :load, i, "pd") * (1 + get(_PM.ref(pm, nw, :load, i), "pshift_up_rel_max", 0.0)), # Not strictly necessary: redundant due to other bounds
         start = _PM.comp_start_value(_PM.ref(pm, nw, :load, i), "pd")
     )
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :pflex, _PM.ids(pm, nw, :load), pflex)
+    report && _PM.sol_component_value(pm, nw, :load, :pflex, _PM.ids(pm, nw, :load), pflex)
 end
 
 function variable_total_flex_demand_reactive(pm::_PM.AbstractActivePowerModel; nw::Int=_PM.nw_id_default, bounded::Bool=true, report::Bool=true)
@@ -93,7 +93,7 @@ function variable_total_flex_demand_reactive(pm::_PM.AbstractPowerModel; nw::Int
         [i in _PM.ids(pm, nw, :load)], base_name="$(nw)_qflex",
         start = _PM.comp_start_value(_PM.ref(pm, nw, :load, i), "qd")
     )
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :qflex, _PM.ids(pm, nw, :load), qflex)
+    report && _PM.sol_component_value(pm, nw, :load, :qflex, _PM.ids(pm, nw, :load), qflex)
 end
 
 "Variable for load curtailment (i.e. involuntary demand reduction) at each load point and each time step"
@@ -104,7 +104,7 @@ function variable_demand_curtailment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_
         upper_bound = _PM.ref(pm, nw, :load, i, "pd"),
         start = 0
     )
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :pcurt, _PM.ids(pm, nw, :load), pcurt)
+    report && _PM.sol_component_value(pm, nw, :load, :pcurt, _PM.ids(pm, nw, :load), pcurt)
 end
 
 "Variable for the power not consumed (voluntary load reduction) at each flex load point and each time step"
@@ -119,7 +119,7 @@ function variable_demand_reduction(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id
         start = 0
     )
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :pred, _PM.ids(pm, nw, :flex_load), pred)
+        _PM.sol_component_value(pm, nw, :load, :pred, _PM.ids(pm, nw, :flex_load), pred)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :pred, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -134,7 +134,7 @@ function variable_energy_not_consumed(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw
         start = 0
     )
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :ered, _PM.ids(pm, nw, :flex_load), ered)
+        _PM.sol_component_value(pm, nw, :load, :ered, _PM.ids(pm, nw, :flex_load), ered)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :ered, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -151,7 +151,7 @@ function variable_demand_shifting_upwards(pm::_PM.AbstractPowerModel; nw::Int=_P
         start = 0
     )
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :pshift_up, _PM.ids(pm, nw, :flex_load), pshift_up)
+        _PM.sol_component_value(pm, nw, :load, :pshift_up, _PM.ids(pm, nw, :flex_load), pshift_up)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :pshift_up, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -167,7 +167,7 @@ function variable_total_demand_shifting_upwards(pm::_PM.AbstractPowerModel; nw::
         start = 0
     )
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :eshift_up, _PM.ids(pm, nw, :flex_load), eshift_up)
+        _PM.sol_component_value(pm, nw, :load, :eshift_up, _PM.ids(pm, nw, :flex_load), eshift_up)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :eshift_up, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -184,7 +184,7 @@ function variable_demand_shifting_downwards(pm::_PM.AbstractPowerModel; nw::Int=
         start = 0
     )
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :pshift_down, _PM.ids(pm, nw, :flex_load), pshift_down)
+        _PM.sol_component_value(pm, nw, :load, :pshift_down, _PM.ids(pm, nw, :flex_load), pshift_down)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :pshift_down, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end
@@ -199,7 +199,7 @@ function variable_total_demand_shifting_downwards(pm::_PM.AbstractPowerModel; nw
         start = 0
     )
     if report
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :eshift_down, _PM.ids(pm, nw, :flex_load), eshift_down)
+        _PM.sol_component_value(pm, nw, :load, :eshift_down, _PM.ids(pm, nw, :flex_load), eshift_down)
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :load, :eshift_down, _PM.ids(pm, nw, :fixed_load), 0.0)
     end
 end

--- a/src/core/gen.jl
+++ b/src/core/gen.jl
@@ -10,6 +10,6 @@ function expression_gen_curtailment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_i
     )
     if report
         _IM.sol_component_fixed(pm, _PM.pm_it_sym, nw, :gen, :pgcurt, _PM.ids(pm, nw, :dgen), 0.0)
-        _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :gen, :pgcurt, _PM.ids(pm, nw, :ndgen), pgcurt)
+        _PM.sol_component_value(pm, nw, :gen, :pgcurt, _PM.ids(pm, nw, :ndgen), pgcurt)
     end
 end

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -99,7 +99,7 @@ end
 
 function objective_reliability(pm::_PM.AbstractPowerModel)
     return JuMP.@objective(pm.model, Min,
-        sum(pm.ref[:contingency_prob][s] *
+        sum(pm.ref[:it][:pm][:contingency_prob][s] *
             sum(
                 calc_gen_cost(pm, n)
                 + calc_convdc_ne_cost(pm, n)
@@ -109,7 +109,7 @@ function objective_reliability(pm::_PM.AbstractPowerModel)
                 + calc_load_cost(pm, n)
                 + calc_contingency_cost(pm, n)
             for (sc, n) in contingency)
-        for (s, contingency) in pm.ref[:contingency])
+        for (s, contingency) in pm.ref[:it][:pm][:contingency])
     )
 end
 
@@ -135,7 +135,7 @@ function calc_gen_cost(pm::_PM.AbstractPowerModel, n::Int)
     gen = _PM.ref(pm, n, :gen)
     cost = sum(calc_single_gen_cost(i,g["cost"]) for (i,g) in gen)
     if get(pm.setting, "add_co2_cost", false)
-        cost += sum(g["emission_factor"] * _PM.var(pm,n,:pg,i) * pm.ref[:co2_emission_cost] for (i,g) in gen)
+        cost += sum(g["emission_factor"] * _PM.var(pm,n,:pg,i) * pm.ref[:it][:pm][:co2_emission_cost] for (i,g) in gen)
     end
     ndgen = _PM.ref(pm, n, :ndgen)
     if !isempty(ndgen)
@@ -240,7 +240,7 @@ end
 function calc_contingency_cost(pm::_PM.AbstractPowerModel, n::Int)
     load = _PM.ref(pm, n, :load)
     cost = 0.0
-    if n ∉ [parse(Int, t) for t in keys(pm.ref[:contingency]["0"])]
+    if n ∉ [parse(Int, t) for t in keys(pm.ref[:it][:pm][:contingency]["0"])]
         cost += sum(l["cost_voll"]*_PM.var(pm, n, :pinter, i) for (i,l) in load)
     end
     return cost

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -99,7 +99,7 @@ end
 
 function objective_reliability(pm::_PM.AbstractPowerModel)
     return JuMP.@objective(pm.model, Min,
-        sum(pm.ref[:it][:pm][:contingency_prob][s] *
+        sum(pm.ref[:it][_PM.pm_it_sym][:contingency_prob][s] *
             sum(
                 calc_gen_cost(pm, n)
                 + calc_convdc_ne_cost(pm, n)
@@ -109,7 +109,7 @@ function objective_reliability(pm::_PM.AbstractPowerModel)
                 + calc_load_cost(pm, n)
                 + calc_contingency_cost(pm, n)
             for (sc, n) in contingency)
-        for (s, contingency) in pm.ref[:it][:pm][:contingency])
+        for (s, contingency) in pm.ref[:it][_PM.pm_it_sym][:contingency])
     )
 end
 
@@ -135,7 +135,7 @@ function calc_gen_cost(pm::_PM.AbstractPowerModel, n::Int)
     gen = _PM.ref(pm, n, :gen)
     cost = sum(calc_single_gen_cost(i,g["cost"]) for (i,g) in gen)
     if get(pm.setting, "add_co2_cost", false)
-        cost += sum(g["emission_factor"] * _PM.var(pm,n,:pg,i) * pm.ref[:it][:pm][:co2_emission_cost] for (i,g) in gen)
+        cost += sum(g["emission_factor"] * _PM.var(pm,n,:pg,i) * pm.ref[:it][_PM.pm_it_sym][:co2_emission_cost] for (i,g) in gen)
     end
     ndgen = _PM.ref(pm, n, :ndgen)
     if !isempty(ndgen)
@@ -240,7 +240,7 @@ end
 function calc_contingency_cost(pm::_PM.AbstractPowerModel, n::Int)
     load = _PM.ref(pm, n, :load)
     cost = 0.0
-    if n ∉ [parse(Int, t) for t in keys(pm.ref[:it][:pm][:contingency]["0"])]
+    if n ∉ [parse(Int, t) for t in keys(pm.ref[:it][_PM.pm_it_sym][:contingency]["0"])]
         cost += sum(l["cost_voll"]*_PM.var(pm, n, :pinter, i) for (i,l) in load)
     end
     return cost

--- a/src/core/ref_extension.jl
+++ b/src/core/ref_extension.jl
@@ -3,7 +3,7 @@
 "Add to `ref` the keys for handling dispatchable and non-dispatchable generators"
 function ref_add_gen!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
 
-    for (n, nw_ref) in ref[:it][:pm][:nw]
+    for (n, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         # Dispatchable generators. Their power varies between `pmin` and `pmax` and cannot be curtailed.
         nw_ref[:dgen] = Dict(x for x in nw_ref[:gen] if x.second["dispatchable"] == true)
         # Non-dispatchable generators. Their reference power `pref` can be curtailed.
@@ -16,7 +16,7 @@ end
 
 function ref_add_storage!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
 
-    for (n, nw_ref) in ref[:it][:pm][:nw]
+    for (n, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         if haskey(nw_ref, :storage)
             nw_ref[:storage_bounded_absorption] = Dict(x for x in nw_ref[:storage] if 0.0 < get(x.second, "max_energy_absorption", Inf) < Inf)
         end
@@ -24,7 +24,7 @@ function ref_add_storage!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
 end
 
 function ref_add_ne_storage!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
-    for (n, nw_ref) in ref[:it][:pm][:nw]
+    for (n, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         if haskey(nw_ref, :ne_storage)
             bus_storage_ne = Dict([(i, []) for (i,bus) in nw_ref[:bus]])
             for (i,storage) in nw_ref[:ne_storage]
@@ -42,7 +42,7 @@ end
 "Add to `ref` the keys for handling flexible demand"
 function ref_add_flex_load!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
 
-    for (n, nw_ref) in ref[:it][:pm][:nw]
+    for (n, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         # Loads that can be made flexible, depending on investment decision
         nw_ref[:flex_load] = Dict(x for x in nw_ref[:load] if x.second["flex"] == 1)
         # Loads that are not flexible and do not have an associated investment decision
@@ -51,17 +51,17 @@ function ref_add_flex_load!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
 
     # Compute the total energy demand of each flex load and store it in the first hour nw
     for nw in nw_ids(data; hour = 1)
-        if haskey(ref[:it][:pm][:nw][nw], :time_elapsed)
-            time_elapsed = ref[:it][:pm][:nw][nw][:time_elapsed]
+        if haskey(ref[:it][_PM.pm_it_sym][:nw][nw], :time_elapsed)
+            time_elapsed = ref[:it][_PM.pm_it_sym][:nw][nw][:time_elapsed]
         else
             Memento.warn(_LOGGER, "network data should specify time_elapsed, using 1.0 as a default")
             time_elapsed = 1.0
         end
         timeseries_nw_ids = similar_ids(data, nw, hour = 1:dim_length(data,:hour))
-        for (l, load) in ref[:it][:pm][:nw][nw][:flex_load]
+        for (l, load) in ref[:it][_PM.pm_it_sym][:nw][nw][:flex_load]
             # `ref` instead of `data` must be used to access loads, since the former has
             # already been filtered to remove inactive loads.
-            load["ed"] = time_elapsed * sum(ref[:it][:pm][:nw][n][:load][l]["pd"] for n in timeseries_nw_ids)
+            load["ed"] = time_elapsed * sum(ref[:it][_PM.pm_it_sym][:nw][n][:load][l]["pd"] for n in timeseries_nw_ids)
         end
     end
 end
@@ -71,7 +71,7 @@ end
 
 "Like ref_add_ne_branch!, but ne_buspairs are built using calc_buspair_parameters_allbranches"
 function ref_add_ne_branch_allbranches!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
-    for (nw, nw_ref) in ref[:it][:pm][:nw]
+    for (nw, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         if !haskey(nw_ref, :ne_branch)
             Memento.error(_LOGGER, "required ne_branch data not found")
         end
@@ -102,7 +102,7 @@ Add to `ref` the following keys:
 - `:frb_ne_branch`: the set of `ne_branch`es whose `f_bus` is the reference bus.
 """
 function ref_add_frb_branch!(ref::Dict{Symbol,Any}, data::Dict{String,<:Any})
-    for (nw, nw_ref) in ref[:it][:pm][:nw]
+    for (nw, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         ref_bus_id = first(keys(nw_ref[:ref_buses]))
 
         frb_branch = Dict{Int,Any}()
@@ -131,7 +131,7 @@ Add to `ref` the following keys:
 - `:oltc_ne_branch`: the set of `frb_ne_branch`es that are OLTCs.
 """
 function ref_add_oltc_branch!(ref::Dict{Symbol,Any}, data::Dict{String,<:Any})
-    for (nw, nw_ref) in ref[:it][:pm][:nw]
+    for (nw, nw_ref) in ref[:it][_PM.pm_it_sym][:nw]
         if !haskey(nw_ref, :frb_branch)
             Memento.error(_LOGGER, "ref_add_oltc_branch! must be called after ref_add_frb_branch!")
         end

--- a/src/core/reliability.jl
+++ b/src/core/reliability.jl
@@ -8,7 +8,7 @@ function variable_demand_interruption(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw
         start = 0
     )
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :load, :pinter, _PM.ids(pm, nw, :load), pinter)
+    report && _PM.sol_component_value(pm, nw, :load, :pinter, _PM.ids(pm, nw, :load), pinter)
 end
 
 

--- a/src/core/storage.jl
+++ b/src/core/storage.jl
@@ -14,7 +14,7 @@ function variable_absorbed_energy(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :storage, :e_abs, _PM.ids(pm, nw, :storage_bounded_absorption), e_abs)
+    report && _PM.sol_component_value(pm, nw, :storage, :e_abs, _PM.ids(pm, nw, :storage_bounded_absorption), e_abs)
 end
 
 function variable_absorbed_energy_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, bounded::Bool = true, report::Bool=true)
@@ -29,7 +29,7 @@ function variable_absorbed_energy_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :e_abs_ne, _PM.ids(pm, nw, :ne_storage_bounded_absorption), e_abs)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :e_abs_ne, _PM.ids(pm, nw, :ne_storage_bounded_absorption), e_abs)
 end
 
 function variable_storage_power_ne(pm::_PM.AbstractPowerModel; kwargs...)
@@ -63,7 +63,7 @@ function variable_storage_power_real_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :ps_ne, _PM.ids(pm, nw, :ne_storage), ps)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :ps_ne, _PM.ids(pm, nw, :ne_storage), ps)
 end
 
 function variable_storage_power_imaginary_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, bounded::Bool=true, report::Bool=true)
@@ -81,7 +81,7 @@ function variable_storage_power_imaginary_ne(pm::_PM.AbstractPowerModel; nw::Int
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :qs_ne, _PM.ids(pm, nw, :ne_storage), qs)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :qs_ne, _PM.ids(pm, nw, :ne_storage), qs)
 end
 
 "apo models ignore reactive power flows"
@@ -109,7 +109,7 @@ function variable_storage_power_control_imaginary_ne(pm::_PM.AbstractPowerModel;
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :qsc_ne, _PM.ids(pm, nw, :ne_storage), qsc)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :qsc_ne, _PM.ids(pm, nw, :ne_storage), qsc)
 end
 
 "apo models ignore reactive power flows"
@@ -134,7 +134,7 @@ function variable_storage_energy_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_i
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :se_ne, _PM.ids(pm, nw, :ne_storage), se)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :se_ne, _PM.ids(pm, nw, :ne_storage), se)
 end
 
 function variable_storage_charge_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, bounded::Bool=true, report::Bool=true)
@@ -150,7 +150,7 @@ function variable_storage_charge_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_i
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :sc_ne, _PM.ids(pm, nw, :ne_storage), sc)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :sc_ne, _PM.ids(pm, nw, :ne_storage), sc)
 end
 
 function variable_storage_discharge_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, bounded::Bool=true, report::Bool=true)
@@ -166,7 +166,7 @@ function variable_storage_discharge_ne(pm::_PM.AbstractPowerModel; nw::Int=_PM.n
         end
     end
 
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :sd_ne, _PM.ids(pm, nw, :ne_storage), sd)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :sd_ne, _PM.ids(pm, nw, :ne_storage), sd)
 end
 
 function variable_storage_indicator(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, relax::Bool=false, report::Bool=true)
@@ -189,7 +189,7 @@ function variable_storage_indicator(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_i
     else
         z = _PM.var(pm, nw)[:z_strg_ne] = _PM.var(pm, first_n)[:z_strg_ne]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :isbuilt, _PM.ids(pm, nw, :ne_storage), z)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :isbuilt, _PM.ids(pm, nw, :ne_storage), z)
 end
 
 function variable_storage_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, relax::Bool=false, report::Bool=true)
@@ -212,7 +212,7 @@ function variable_storage_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_
     else
         investment = _PM.var(pm, nw)[:z_strg_ne_investment] = _PM.var(pm, first_n)[:z_strg_ne_investment]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_storage, :investment, _PM.ids(pm, nw, :ne_storage), investment)
+    report && _PM.sol_component_value(pm, nw, :ne_storage, :investment, _PM.ids(pm, nw, :ne_storage), investment)
 end
 
 

--- a/src/core/t-d_coupling.jl
+++ b/src/core/t-d_coupling.jl
@@ -280,7 +280,7 @@ end
 """
 Apply bounds on reactive power exchange at the point of common coupling (PCC) of a distribution nw.
 """
-function constraint_td_coupling_power_reactive_bounds(d_pm::_PM.AbstractBFModel; nw::Int=d__PM.nw_id_default)
+function constraint_td_coupling_power_reactive_bounds(d_pm::_PM.AbstractBFModel; nw::Int=_PM.nw_id_default)
     sub_nw = dim_prop(d_pm, nw, :sub_nw)
     d_gen = sub_nw["d_gen"]
     qs_ratio_bound = sub_nw["qs_ratio_bound"] # Allowable fraction of rated apparent power

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -19,7 +19,7 @@ function variable_ne_branch_indicator(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw
     else
         z_branch_ne = _PM.var(pm, nw)[:branch_ne] = _PM.var(pm, first_n)[:branch_ne]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_branch, :built, _PM.ids(pm, nw, :ne_branch), z_branch_ne)
+    report && _PM.sol_component_value(pm, nw, :ne_branch, :built, _PM.ids(pm, nw, :ne_branch), z_branch_ne)
 end
 
 function variable_ne_branch_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, relax::Bool=false, report::Bool=true)
@@ -42,5 +42,5 @@ function variable_ne_branch_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM.n
     else
         investment = _PM.var(pm, nw)[:branch_ne_investment] = _PM.var(pm, first_n)[:branch_ne_investment]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :ne_branch, :investment, _PM.ids(pm, nw, :ne_branch), investment)
+    report && _PM.sol_component_value(pm, nw, :ne_branch, :investment, _PM.ids(pm, nw, :ne_branch), investment)
 end

--- a/src/core/variableconv.jl
+++ b/src/core/variableconv.jl
@@ -19,7 +19,7 @@ function variable_ne_converter_indicator(pm::_PM.AbstractPowerModel; nw::Int=_PM
     else
         Z_dc_conv_ne = _PM.var(pm, nw)[:conv_ne] = _PM.var(pm, first_n)[:conv_ne]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :convdc_ne, :isbuilt, _PM.ids(pm, nw, :convdc_ne), Z_dc_conv_ne)
+    report && _PM.sol_component_value(pm, nw, :convdc_ne, :isbuilt, _PM.ids(pm, nw, :convdc_ne), Z_dc_conv_ne)
 end
 
 function variable_ne_converter_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, relax::Bool=false, report::Bool=true)
@@ -42,7 +42,7 @@ function variable_ne_converter_investment(pm::_PM.AbstractPowerModel; nw::Int=_P
     else
         investment = _PM.var(pm, nw)[:conv_ne_investment] = _PM.var(pm, first_n)[:conv_ne_investment]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :convdc_ne, :investment, _PM.ids(pm, nw, :convdc_ne), investment)
+    report && _PM.sol_component_value(pm, nw, :convdc_ne, :investment, _PM.ids(pm, nw, :convdc_ne), investment)
 end
 
 # To be used instead of _PMACDC.variable_dc_converter_ne() - supports deduplication of variables

--- a/src/core/variabledcgrid.jl
+++ b/src/core/variabledcgrid.jl
@@ -19,7 +19,7 @@ function variable_ne_branchdc_indicator(pm::_PM.AbstractPowerModel; nw::Int=_PM.
     else
         Z_dc_branch_ne = _PM.var(pm, nw)[:branchdc_ne] = _PM.var(pm, first_n)[:branchdc_ne]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :branchdc_ne, :isbuilt, _PM.ids(pm, nw, :branchdc_ne), Z_dc_branch_ne)
+    report && _PM.sol_component_value(pm, nw, :branchdc_ne, :isbuilt, _PM.ids(pm, nw, :branchdc_ne), Z_dc_branch_ne)
 end
 
 function variable_ne_branchdc_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM.nw_id_default, relax::Bool=false, report::Bool=true)
@@ -42,5 +42,5 @@ function variable_ne_branchdc_investment(pm::_PM.AbstractPowerModel; nw::Int=_PM
     else
         investment = _PM.var(pm, nw)[:branchdc_ne_investment] = _PM.var(pm, first_n)[:branchdc_ne_investment]
     end
-    report && _IM.sol_component_value(pm, _PM.pm_it_sym, nw, :branchdc_ne, :investment, _PM.ids(pm, nw, :branchdc_ne), investment)
+    report && _PM.sol_component_value(pm, nw, :branchdc_ne, :investment, _PM.ids(pm, nw, :branchdc_ne), investment)
 end

--- a/src/io/multinetwork.jl
+++ b/src/io/multinetwork.jl
@@ -18,8 +18,8 @@ function make_multinetwork(
         sn_data::Dict{String,Any},
         time_series::Dict{String,Any};
         global_keys = ["dim","multinetwork","name","per_unit","source_type","source_version"],
-        number_of_nws::Int = length(sn_data["dim"][:li]),
-        nw_id_offset::Int = sn_data["dim"][:offset],
+        number_of_nws::Int = length(dim(sn_data)[:li]),
+        nw_id_offset::Int = dim(sn_data)[:offset],
         check_dim::Bool = true
     )
 
@@ -158,8 +158,8 @@ function slice_multinetwork(data::Dict{String,Any}; kwargs...)
     for k in setdiff(keys(data), ("dim", "nw"))
         slice[k] = data[k]
     end
-    dim, ids = slice_dim(data["dim"]; kwargs...)
-    slice["dim"] = dim
+    dim_dict, ids = slice_dim(dim(data); kwargs...)
+    slice["dim"] = dim_dict
     slice["nw"] = Dict{String,Any}()
     for (new_id, old_id) in enumerate(ids)
         slice["nw"]["$new_id"] = data["nw"]["$old_id"]

--- a/src/prob/flexible_tnep.jl
+++ b/src/prob/flexible_tnep.jl
@@ -163,7 +163,7 @@ function post_flex_tnep(pm::_PM.AbstractPowerModel; objective::Bool=true)
             _PMACDC.constraint_conv_transformer(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor(pm, i; nw = n)
             _PMACDC.constraint_conv_filter(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle(pm, i; nw = n)
             end
         end
@@ -174,7 +174,7 @@ function post_flex_tnep(pm::_PM.AbstractPowerModel; objective::Bool=true)
             _PMACDC.constraint_conv_transformer_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_filter_ne(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc_ne][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc_ne,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle_ne(pm, i; nw = n)
             end
         end

--- a/src/prob/reliability_tnep.jl
+++ b/src/prob/reliability_tnep.jl
@@ -15,7 +15,7 @@ end
 ""
 function post_reliability_tnep(pm::_PM.AbstractPowerModel)
     # VARIABLES: defined within PowerModels(ACDC) can directly be used, other variables need to be defined in the according sections of the code
-    base_nw = [parse(Int, i) for i in keys(pm.ref[:it][:pm][:contingency]["0"])] # reliability specific - networks (times) in base scenario without contingencies
+    base_nw = [parse(Int, i) for i in keys(pm.ref[:it][_PM.pm_it_sym][:contingency]["0"])] # reliability specific - networks (times) in base scenario without contingencies
     for n in nw_ids(pm)
 
         # AC Bus
@@ -143,7 +143,7 @@ function post_reliability_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor(pm, i; nw = n)
             _PMACDC.constraint_conv_filter(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle(pm, i; nw = n)
             end
         end
@@ -154,7 +154,7 @@ function post_reliability_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_filter_ne(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc_ne][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc_ne,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle_ne(pm, i; nw = n)
             end
         end

--- a/src/prob/simple_stochastic_flexible_tnep.jl
+++ b/src/prob/simple_stochastic_flexible_tnep.jl
@@ -145,7 +145,7 @@ function post_simple_stoch_flex_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor(pm, i; nw = n)
             _PMACDC.constraint_conv_filter(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle(pm, i; nw = n)
             end
         end
@@ -156,7 +156,7 @@ function post_simple_stoch_flex_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_filter_ne(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc_ne][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc_ne,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle_ne(pm, i; nw = n)
             end
         end

--- a/src/prob/stochastic_flexible_tnep.jl
+++ b/src/prob/stochastic_flexible_tnep.jl
@@ -148,7 +148,7 @@ function post_stoch_flex_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor(pm, i; nw = n)
             _PMACDC.constraint_conv_filter(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle(pm, i; nw = n)
             end
         end
@@ -159,7 +159,7 @@ function post_stoch_flex_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_filter_ne(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc_ne][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc_ne,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle_ne(pm, i; nw = n)
             end
         end

--- a/src/prob/storage_tnep.jl
+++ b/src/prob/storage_tnep.jl
@@ -142,7 +142,7 @@ function post_strg_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor(pm, i; nw = n)
             _PMACDC.constraint_conv_filter(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle(pm, i; nw = n)
             end
         end
@@ -153,7 +153,7 @@ function post_strg_tnep(pm::_PM.AbstractPowerModel)
             _PMACDC.constraint_conv_transformer_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_reactor_ne(pm, i; nw = n)
             _PMACDC.constraint_conv_filter_ne(pm, i; nw = n)
-            if pm.ref[:it][:pm][:nw][n][:convdc_ne][i]["islcc"] == 1
+            if _PM.ref(pm,n,:convdc_ne,i,"islcc") == 1
                 _PMACDC.constraint_conv_firing_angle_ne(pm, i; nw = n)
             end
         end

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -46,9 +46,9 @@
     _FP.add_dimension!(sn_data, :hour, 4)
     _FP.add_dimension!(sn_data, :scenario, Dict(s => Dict{String,Any}("probability"=>s/6) for s in 1:3))
     _FP.add_dimension!(sn_data, :sub_nw, 2; metadata = Dict{String,Any}("description"=>"sub_nws model different physical networks"))
-    dt = Dict{String,Any}("dim"=>sn_data["dim"], "multinetwork"=>true, "nw"=>Dict{String,Any}("1"=>sn_data)) # Fake a multinetwork data structure
+    dt = Dict{String,Any}("dim"=>_FP.dim(sn_data), "multinetwork"=>true, "nw"=>Dict{String,Any}("1"=>sn_data)) # Fake a multinetwork data structure
     pm = _PM.instantiate_model(dt, _PM.ACPPowerModel, pm->nothing)
-    dim = pm.ref[:it][:pm][:dim]
+    dim = _FP.dim(pm)
 
     dim_shift = deepcopy(dim)
     _FP.shift_ids!(dim_shift, 24)

--- a/test/io/multiple_years.jl
+++ b/test/io/multiple_years.jl
@@ -44,7 +44,7 @@ function create_multi_year_network_data(case, number_of_hours, number_of_scenari
         year = planning_years[year_idx]
         file = base_file * "$year" * ".m"
         data = _FP.parse_file(file)
-        data["dim"] = my_data["dim"]
+        data["dim"] = _FP.dim(my_data)
         _FP.scale_data!(data; year_idx, cost_scale_factor)
         add_one_year!(my_data, case, data, year_idx)
     end

--- a/test/scripts/test_dist_nw_model.jl
+++ b/test/scripts/test_dist_nw_model.jl
@@ -86,7 +86,7 @@ end
 
 result = _FP.strg_tnep(data, _FP.BFARadPowerModel, optimizer)
 # Two-step alternative
-#pm = _PM.instantiate_model(data, _FP.BFARadPowerModel, _FP.post_strg_tnep; ref_extensions=[ref_add_gen!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _PM.ref_add_on_off_va_bounds!, _FP.ref_add_ne_branch_allbranches!, _FP.ref_add_frb_branch!, _FP.ref_add_oltc_branch!])
+#pm = _PM.instantiate_model(data, _FP.BFARadPowerModel, _FP.post_strg_tnep; ref_extensions=[_FP.ref_add_gen!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _PM.ref_add_on_off_va_bounds!, _FP.ref_add_ne_branch_allbranches!, _FP.ref_add_frb_branch!, _FP.ref_add_oltc_branch!])
 #result = _PM.optimize_model!(pm; optimizer, solution_processors=[_PM.sol_data_model!])
 @assert result["termination_status"] ∈ (_PM.OPTIMAL, _PM.LOCALLY_SOLVED) "$(result["optimizer"]) termination status: $(result["termination_status"])"
 

--- a/test/scripts/test_dist_opf.jl
+++ b/test/scripts/test_dist_opf.jl
@@ -19,7 +19,7 @@ data = _PM.parse_file(data_file)
 
 result = _FP.opf_rad(data, _FP.BFARadPowerModel, optimizer)
 # Two-step alternative
-#pm = _PM.instantiate_model(data, _FP.BFARadPowerModel, _FP.build_opf_rad; ref_extensions=[ref_add_gen!, _FP.ref_add_frb_branch!,_FP.ref_add_oltc_branch!])
+#pm = _PM.instantiate_model(data, _FP.BFARadPowerModel, _FP.build_opf_rad; ref_extensions=[_FP.ref_add_gen!, _FP.ref_add_frb_branch!,_FP.ref_add_oltc_branch!])
 #result = _PM.optimize_model!(pm; optimizer=optimizer, solution_processors=[_PM.sol_data_model!])
 @assert result["termination_status"] ∈ (_PM.OPTIMAL, _PM.LOCALLY_SOLVED) "$(result["optimizer"]) termination status: $(result["termination_status"])"
 

--- a/test/scripts/test_dist_tnep.jl
+++ b/test/scripts/test_dist_tnep.jl
@@ -19,7 +19,7 @@ data = _PM.parse_file(data_file)
 
 result = _FP.tnep_rad(data, _FP.BFARadPowerModel, optimizer)
 # Two-step alternative
-#pm = _PM.instantiate_model(data, _FP.BFARadPowerModel, _FP.build_tnep_rad; ref_extensions=[ref_add_gen!, _PM.ref_add_on_off_va_bounds!,_FP.ref_add_ne_branch_allbranches!,_FP.ref_add_frb_branch!,_FP.ref_add_oltc_branch!])
+#pm = _PM.instantiate_model(data, _FP.BFARadPowerModel, _FP.build_tnep_rad; ref_extensions=[_FP.ref_add_gen!, _PM.ref_add_on_off_va_bounds!,_FP.ref_add_ne_branch_allbranches!,_FP.ref_add_frb_branch!,_FP.ref_add_oltc_branch!])
 #result = _PM.optimize_model!(pm; optimizer=optimizer, solution_processors=[_PM.sol_data_model!])
 @assert result["termination_status"] ∈ (_PM.OPTIMAL, _PM.LOCALLY_SOLVED) "$(result["optimizer"]) termination status: $(result["termination_status"])"
 

--- a/test/scripts/test_environmental_model.jl
+++ b/test/scripts/test_environmental_model.jl
@@ -22,12 +22,12 @@ import CSV
 include("../io/create_profile.jl")
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 # TEST SCRIPT to run multi-period optimisation of demand flexibility, AC & DC lines and storage investments for the Italian case
 ################# INPUT PARAMETERS ######################

--- a/test/scripts/test_geo_plotting.jl
+++ b/test/scripts/test_geo_plotting.jl
@@ -24,13 +24,13 @@ import JSON
 import CSV
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cplex = JuMP.with_optimizer(CPLEX.Optimizer)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cplex = CPLEX.Optimizer
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 # Read in renewable generation and demand profile data
 #pv_sicily, pv_south_central, wind_sicily = _FP.read_res_and_demand_data()

--- a/test/scripts/test_italian_case.jl
+++ b/test/scripts/test_italian_case.jl
@@ -22,12 +22,12 @@ import JSON
 import CSV
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-#gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-#mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+#gurobi = Gurobi.Optimizer
+#mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 # TEST SCRIPT to run multi-period optimisation of demand flexibility, AC & DC lines and storage investments for the Italian case
 ################# INPUT PARAMETERS ######################

--- a/test/scripts/test_json_converter.jl
+++ b/test/scripts/test_json_converter.jl
@@ -33,14 +33,14 @@ mn_data = _FP.convert_JSON(file) # Conversion caveats and function parameters: s
 
 result = _FP.stoch_flex_tnep(mn_data, _PM.DCPPowerModel, optimizer)
 # Two-step alternative: exposes `pm`
-#pm = _PM.instantiate_model(mn_data, _PM.DCPPowerModel, _FP.post_stoch_flex_tnep; ref_extensions=[ref_add_gen!, _PMACDC.add_ref_dcgrid!, _PMACDC.add_candidate_dcgrid!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _PM.ref_add_ne_branch!])
+#pm = _PM.instantiate_model(mn_data, _PM.DCPPowerModel, _FP.post_stoch_flex_tnep; ref_extensions=[_FP.ref_add_gen!, _PMACDC.add_ref_dcgrid!, _PMACDC.add_candidate_dcgrid!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _PM.ref_add_ne_branch!])
 #result = _PM.optimize_model!(pm; optimizer=optimizer)
 
 # Distribution network
 
 #result = _FP.stoch_flex_tnep(mn_data, _FP.BFARadPowerModel, optimizer)
 # Two-step alternative: exposes `pm`
-#pm = _PM.instantiate_model(mn_data, _FP.BFARadPowerModel, _FP.post_stoch_flex_tnep; ref_extensions=[ref_add_gen!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _FP.ref_add_ne_branch_allbranches!, _FP.ref_add_frb_branch!, _FP.ref_add_oltc_branch!])
+#pm = _PM.instantiate_model(mn_data, _FP.BFARadPowerModel, _FP.post_stoch_flex_tnep; ref_extensions=[_FP.ref_add_gen!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _FP.ref_add_ne_branch_allbranches!, _FP.ref_add_frb_branch!, _FP.ref_add_oltc_branch!])
 #result = _PM.optimize_model!(pm; optimizer=optimizer, solution_processors=[_PM.sol_data_model!])
 
 

--- a/test/scripts/test_line_replacement.jl
+++ b/test/scripts/test_line_replacement.jl
@@ -22,12 +22,12 @@ import JSON
 import CSV
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 # TEST SCRIPT to run multi-period optimisation of demand flexibility, AC & DC lines and storage investments for the Italian case
 ################# INPUT PARAMETERS ######################

--- a/test/scripts/test_mc.jl
+++ b/test/scripts/test_mc.jl
@@ -17,11 +17,11 @@ import JSON
 import CSV
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 cd("/Users/hergun/.julia/dev/FlexPlan")
 for year = 0:1

--- a/test/scripts/test_multiple_years.jl
+++ b/test/scripts/test_multiple_years.jl
@@ -46,7 +46,7 @@ s = Dict("output" => Dict("branch_flows" => true), "conv_losses_mp" => false, "p
 #result = _FP.stoch_flex_tnep(data, model_type, optimizer, multinetwork=_PM._IM.ismultinetwork(data); setting=s)
 
 # Two-step alternative, exposes pm
-pm = _PM.instantiate_model(data, model_type, _FP.post_stoch_flex_tnep; ref_extensions=[ref_add_gen!, _PMACDC.add_ref_dcgrid!, _PMACDC.add_candidate_dcgrid!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _PM.ref_add_ne_branch!], setting=s)
+pm = _PM.instantiate_model(data, model_type, _FP.post_stoch_flex_tnep; ref_extensions=[_FP.ref_add_gen!, _PMACDC.add_ref_dcgrid!, _PMACDC.add_candidate_dcgrid!, _FP.ref_add_storage!, _FP.ref_add_ne_storage!, _FP.ref_add_flex_load!, _PM.ref_add_on_off_va_bounds!, _PM.ref_add_ne_branch!], setting=s)
 result = _PM.optimize_model!(pm; optimizer)
 
 @assert result["termination_status"] ∈ (_PM.OPTIMAL, _PM.LOCALLY_SOLVED) "$(result["optimizer"]) termination status: $(result["termination_status"])"

--- a/test/scripts/test_reliability.jl
+++ b/test/scripts/test_reliability.jl
@@ -16,7 +16,7 @@ include("../io/plots.jl")
 
 # Solver configurations:
 
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
 
 
 # Input parameters:

--- a/test/scripts/test_reliability_tnep.jl
+++ b/test/scripts/test_reliability_tnep.jl
@@ -24,12 +24,12 @@ import JSON
 import CSV
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-#gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-#mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+#gurobi = Gurobi.Optimizer
+#mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 ################# INPUT PARAMETERS ######################
 number_of_hours = 60 # Number of time points

--- a/test/scripts/test_stochastic_variation.jl
+++ b/test/scripts/test_stochastic_variation.jl
@@ -24,12 +24,12 @@ import CSV
 import Plots
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 res = ones(1,11)
 idx = 0

--- a/test/scripts/test_stochastic_variation_noflex.jl
+++ b/test/scripts/test_stochastic_variation_noflex.jl
@@ -24,12 +24,12 @@ import CSV
 import Plots
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 res = ones(1,11)
 idx = 0

--- a/test/scripts/test_stochastic_variation_noflex_nostrg.jl
+++ b/test/scripts/test_stochastic_variation_noflex_nostrg.jl
@@ -24,12 +24,12 @@ import CSV
 import Plots
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 res = ones(1,11)
 idx = 0

--- a/test/scripts/tests_flex_demand.jl
+++ b/test/scripts/tests_flex_demand.jl
@@ -25,13 +25,13 @@ import Cbc
 #import CPLEX
 
 # Solver configurations
-#scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-#ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-#cplex = JuMP.with_optimizer(CPLEX.Optimizer)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-#gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-#mosek = JuMP.with_optimizer(Mosek.Optimizer)
-#juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+#scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+#ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+#cplex = CPLEX.Optimizer
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+#gurobi = Gurobi.Optimizer
+#mosek = Mosek.Optimizer
+#juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 
 # TEST SCRIPT to run multi-period optimisation of demand flexibility, AC & DC lines and storage investments

--- a/test/scripts/tests_flex_demand_CIGRE_MV.jl
+++ b/test/scripts/tests_flex_demand_CIGRE_MV.jl
@@ -26,7 +26,7 @@ import JuMP
 import Cbc
 
 # Solver configurations
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, seconds = 20, print_level=0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "seconds"=>20, "print_level"=>0)
 
 
 # Input parameters:

--- a/test/scripts/tests_sensitivities_flex_demand_CIGRE_MV.jl
+++ b/test/scripts/tests_sensitivities_flex_demand_CIGRE_MV.jl
@@ -15,7 +15,7 @@ import JuMP
 import Cbc
 
 # Solver configurations
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, seconds=20, print_level=0)
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "seconds"=>20, "print_level"=>0)
 
 
 # Input parameters:

--- a/test/scripts/tests_strg.jl
+++ b/test/scripts/tests_strg.jl
@@ -21,13 +21,13 @@ import Cbc
 import CPLEX
 
 # Solver configurations
-scs = JuMP.with_optimizer(SCS.Optimizer, max_iters=100000)
-ipopt = JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-4, print_level=0)
-cplex = JuMP.with_optimizer(CPLEX.Optimizer)
-cbc = JuMP.with_optimizer(Cbc.Optimizer, tol=1e-4, print_level=0)
-gurobi = JuMP.with_optimizer(Gurobi.Optimizer)
-mosek = JuMP.with_optimizer(Mosek.Optimizer)
-juniper = JuMP.with_optimizer(Juniper.Optimizer, nl_solver = ipopt, mip_solver= cbc, time_limit= 7200)
+scs = _FP.optimizer_with_attributes(SCS.Optimizer, "max_iters"=>100000)
+ipopt = _FP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>1e-4, "print_level"=>0)
+cplex = CPLEX.Optimizer
+cbc = _FP.optimizer_with_attributes(Cbc.Optimizer, "tol"=>1e-4, "print_level"=>0)
+gurobi = Gurobi.Optimizer
+mosek = Mosek.Optimizer
+juniper = _FP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt, "mip_solver"=>cbc, "time_limit"=>7200)
 
 
 # TEST SCRIPT to run multi-period optimisation of demand flexibility, AC & DC lines and storage investments


### PR DESCRIPTION
- Revert to the requirement that the Julia version be at least 1.5 – the code would not work anyway with Julia versions prior to 1.5.
- Remove `JuMP.with_optimizer` (deprecated).
- Update package internals to the multi-infrastructure conventions adopted in PowerModels since v0.18.
- Fix typos.