### PR TITLE
Add ability to choose period duration when importing JSON files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - This changelog
+- Ability to choose period duration when importing JSON files
 
 ## [0.3.0] - 2022-12-19
 


### PR DESCRIPTION
Add `hour_scale_factor` parameter to `convert_JSON` function. It enables conversion of test cases where the optimization period duration is different from 1 hour.